### PR TITLE
Do not immediataly retry on network errors

### DIFF
--- a/AutomatticTracks/build.gradle
+++ b/AutomatticTracks/build.gradle
@@ -25,7 +25,7 @@ android {
     buildToolsVersion "21.1.2"
 
     defaultConfig {
-        versionName "1.0.3"
+        versionName "1.0.4"
         minSdkVersion 14
         targetSdkVersion 19
     }

--- a/AutomatticTracks/build.gradle
+++ b/AutomatticTracks/build.gradle
@@ -21,13 +21,13 @@ dependencies {
 android {
     publishNonDefault true
 
-    compileSdkVersion 19
-    buildToolsVersion "21.1.2"
+    compileSdkVersion 22
+    buildToolsVersion "22.0.1"
 
     defaultConfig {
         versionName "1.0.4"
         minSdkVersion 14
-        targetSdkVersion 19
+        targetSdkVersion 22
     }
 
     compileOptions {

--- a/AutomatticTracks/src/main/java/com/automattic/android/tracks/TracksClient.java
+++ b/AutomatticTracks/src/main/java/com/automattic/android/tracks/TracksClient.java
@@ -63,7 +63,7 @@ public class TracksClient {
 
     private boolean mPendingFlush = false;
     private static long WAIT_PERIOD_NETWORK_CONNECTION = 2 * 60 * 1000 ; // 2 Minutes
-    private long lastNetworkErrorTimestamp = 0L;
+    private long mLastNetworkErrorTimestamp = 0L;
 
     public static TracksClient getClient(Context ctx) {
         if (null == ctx || !checkBasicConfiguration(ctx)) {
@@ -122,8 +122,8 @@ public class TracksClient {
                         try {
                             //  Make sure to NOT contact the server immediately if it was a previous network connection.
                             // For now there is a fixed time, maybe we can add Exponential backoff later.
-                            boolean shouldWait = lastNetworkErrorTimestamp > 0L
-                                    && (Math.abs(System.currentTimeMillis() - lastNetworkErrorTimestamp) < WAIT_PERIOD_NETWORK_CONNECTION);
+                            boolean shouldWait = mLastNetworkErrorTimestamp > 0L
+                                    && (Math.abs(System.currentTimeMillis() - mLastNetworkErrorTimestamp) < WAIT_PERIOD_NETWORK_CONNECTION);
                             if ((mPendingFlush || (!shouldWait && EventTable.getEventsCount(mContext) > DEFAULT_EVENTS_QUEUE_THREESHOLD))
                                     && NetworkUtils.isNetworkAvailable(mContext)) {
 
@@ -259,7 +259,7 @@ public class TracksClient {
                             } catch (Exception e){
                             }
                             if (isErrorResponse) {
-                                lastNetworkErrorTimestamp = System.currentTimeMillis();
+                                mLastNetworkErrorTimestamp = System.currentTimeMillis();
                                 // Loop on events and keep those events that we must re-enqueue
                                 LinkedList<Event> mustKeepEventsList = new LinkedList<>(); // events we're re-enqueuing
                                 for (Event singleEvent : currentRequest.src) {
@@ -275,7 +275,7 @@ public class TracksClient {
                                     }
                                 }
                             } else {
-                                lastNetworkErrorTimestamp = 0L;
+                                mLastNetworkErrorTimestamp = 0L;
                             }
                         }
                     }

--- a/AutomatticTracks/src/main/java/com/automattic/android/tracks/TracksClient.java
+++ b/AutomatticTracks/src/main/java/com/automattic/android/tracks/TracksClient.java
@@ -62,7 +62,8 @@ public class TracksClient {
 
 
     private boolean mPendingFlush = false;
-
+    private static long WAIT_PERIOD_NETWORK_CONNECTION = 2 * 60 * 1000 ; // 2 Minutes
+    private long lastNetworkErrorTimestamp = 0L;
 
     public static TracksClient getClient(Context ctx) {
         if (null == ctx || !checkBasicConfiguration(ctx)) {
@@ -119,7 +120,11 @@ public class TracksClient {
                     NetworkRequestObject req = null;
                     synchronized (mDbLock) {
                         try {
-                            if ((mPendingFlush || EventTable.getEventsCount(mContext) > DEFAULT_EVENTS_QUEUE_THREESHOLD)
+                            //  Make sure to NOT contact the server immediately if it was a previous network connection.
+                            // For now there is a fixed time, maybe we can add Exponential backoff later.
+                            boolean shouldWait = lastNetworkErrorTimestamp > 0L
+                                    && (Math.abs(System.currentTimeMillis() - lastNetworkErrorTimestamp) < WAIT_PERIOD_NETWORK_CONNECTION);
+                            if ((mPendingFlush || (!shouldWait && EventTable.getEventsCount(mContext) > DEFAULT_EVENTS_QUEUE_THREESHOLD))
                                     && NetworkUtils.isNetworkAvailable(mContext)) {
 
                                 mPendingFlush = false; // We can remove the flushing flag now.
@@ -176,6 +181,7 @@ public class TracksClient {
         // This is the thread that sends the request to the server and wait for the response.
         // single network connection model.
         Thread networkThread = new Thread(new Runnable() {
+
             public void run() {
 
                 while (true) {
@@ -253,6 +259,7 @@ public class TracksClient {
                             } catch (Exception e){
                             }
                             if (isErrorResponse) {
+                                lastNetworkErrorTimestamp = System.currentTimeMillis();
                                 // Loop on events and keep those events that we must re-enqueue
                                 LinkedList<Event> mustKeepEventsList = new LinkedList<>(); // events we're re-enqueuing
                                 for (Event singleEvent : currentRequest.src) {
@@ -267,6 +274,8 @@ public class TracksClient {
                                         mInsertEventsQueue.notifyAll();
                                     }
                                 }
+                            } else {
+                                lastNetworkErrorTimestamp = 0L;
                             }
                         }
                     }


### PR DESCRIPTION
Fix #14 by adding a fixed time of 2 minutes before retrying the network request. Otherwise there is a very high possibility to fall in a loop where the network connection is retried every second.


Also bumps version number to 1.0.4