### PR TITLE
Send events more often to the server

### DIFF
--- a/AutomatticTracks/build.gradle
+++ b/AutomatticTracks/build.gradle
@@ -25,7 +25,7 @@ android {
     buildToolsVersion "22.0.1"
 
     defaultConfig {
-        versionName "1.0.4"
+        versionName "1.0.5"
         minSdkVersion 14
         targetSdkVersion 22
     }

--- a/AutomatticTracks/src/main/java/com/automattic/android/tracks/TracksClient.java
+++ b/AutomatticTracks/src/main/java/com/automattic/android/tracks/TracksClient.java
@@ -29,7 +29,7 @@ public class TracksClient {
     public static final String LIB_VERSION = BuildConfig.VERSION_NAME;
     protected static final String DEFAULT_USER_AGENT = "Nosara Client for Android" + "/" + LIB_VERSION;
     protected static final String NOSARA_REST_API_ENDPOINT_URL_V1_1 = "https://public-api.wordpress.com/rest/v1.1/";
-    protected static final int DEFAULT_EVENTS_QUEUE_THREESHOLD = 10;
+    protected static final int DEFAULT_EVENTS_QUEUE_THREESHOLD = 5;
 
     public static enum NosaraUserType {ANON, WPCOM}
 

--- a/AutomatticTracks/src/main/java/com/automattic/android/tracks/TracksClient.java
+++ b/AutomatticTracks/src/main/java/com/automattic/android/tracks/TracksClient.java
@@ -32,7 +32,7 @@ public class TracksClient {
     public static final String LIB_VERSION = BuildConfig.VERSION_NAME;
     protected static final String DEFAULT_USER_AGENT = "Nosara Client for Android" + "/" + LIB_VERSION;
     protected static final String NOSARA_REST_API_ENDPOINT_URL_V1_1 = "https://public-api.wordpress.com/rest/v1.1/";
-    protected static final int DEFAULT_EVENTS_QUEUE_THREESHOLD = 9;
+    protected static final int DEFAULT_EVENTS_QUEUE_THRESHOLD = 9;
     protected static final int DEFAULT_EVENTS_QUEUE_TIMER_MS = 30000;
 
     public static enum NosaraUserType {ANON, WPCOM}
@@ -134,7 +134,7 @@ public class TracksClient {
                             // For now there is a fixed time, maybe we can add Exponential backoff later.
                             boolean shouldWait = mLastNetworkErrorTimestamp > 0L
                                     && (Math.abs(System.currentTimeMillis() - mLastNetworkErrorTimestamp) < WAIT_PERIOD_NETWORK_CONNECTION);
-                            if ((mPendingFlush || (!shouldWait && EventTable.getEventsCount(mContext) > DEFAULT_EVENTS_QUEUE_THREESHOLD))
+                            if ((mPendingFlush || (!shouldWait && EventTable.getEventsCount(mContext) > DEFAULT_EVENTS_QUEUE_THRESHOLD))
                                     && NetworkUtils.isNetworkAvailable(mContext)) {
                                 mPendingFlush = false; // We can remove the flushing flag now.
                                 try {

--- a/AutomatticTracks/src/main/java/com/automattic/android/tracks/TracksClient.java
+++ b/AutomatticTracks/src/main/java/com/automattic/android/tracks/TracksClient.java
@@ -32,8 +32,8 @@ public class TracksClient {
     public static final String LIB_VERSION = BuildConfig.VERSION_NAME;
     protected static final String DEFAULT_USER_AGENT = "Nosara Client for Android" + "/" + LIB_VERSION;
     protected static final String NOSARA_REST_API_ENDPOINT_URL_V1_1 = "https://public-api.wordpress.com/rest/v1.1/";
-    protected static final int DEFAULT_EVENTS_QUEUE_THREESHOLD = 5;
-    protected static final int DEFAULT_EVENTS_COUNTDOWN_TIMER_MS = 30000;
+    protected static final int DEFAULT_EVENTS_QUEUE_THREESHOLD = 9;
+    protected static final int DEFAULT_EVENTS_QUEUE_TIMER_MS = 30000;
 
     public static enum NosaraUserType {ANON, WPCOM}
 
@@ -65,7 +65,7 @@ public class TracksClient {
     private final LinkedList<NetworkRequestObject> mNetworkQueue = new LinkedList<>();
 
     private boolean mPendingFlush = false;
-    private static long WAIT_PERIOD_NETWORK_CONNECTION = 2 * 60 * 1000 ; // 2 Minutes
+    private static long WAIT_PERIOD_NETWORK_CONNECTION = 2 * 60 * 1000 ; // 2 Minutes timeout in case of network error
     private long mLastNetworkErrorTimestamp = 0L;
 
     // The Handler that ensures events are sent to the server when the app is left opened with no actions.
@@ -127,14 +127,15 @@ public class TracksClient {
                     NetworkRequestObject req = null;
                     synchronized (mDbLock) {
                         try {
+
+                            mHandler.removeCallbacks(mEventsCountdownRunnable); // we can remove any pending updates
+
                             //  Make sure to NOT contact the server immediately if it was a previous network connection.
                             // For now there is a fixed time, maybe we can add Exponential backoff later.
                             boolean shouldWait = mLastNetworkErrorTimestamp > 0L
                                     && (Math.abs(System.currentTimeMillis() - mLastNetworkErrorTimestamp) < WAIT_PERIOD_NETWORK_CONNECTION);
                             if ((mPendingFlush || (!shouldWait && EventTable.getEventsCount(mContext) > DEFAULT_EVENTS_QUEUE_THREESHOLD))
                                     && NetworkUtils.isNetworkAvailable(mContext)) {
-
-                                mHandler.removeCallbacks(mEventsCountdownRunnable); // we can remove the delay updater now.
                                 mPendingFlush = false; // We can remove the flushing flag now.
                                 try {
                                     JSONArray events = new JSONArray();
@@ -167,7 +168,7 @@ public class TracksClient {
                                     Log.e(LOGTAG, "Exception creating the request JSON object", err);
                                 }
                             } else {
-                                mHandler.postDelayed(mEventsCountdownRunnable, DEFAULT_EVENTS_COUNTDOWN_TIMER_MS);
+                                mHandler.postDelayed(mEventsCountdownRunnable, DEFAULT_EVENTS_QUEUE_TIMER_MS);
                                 mDbLock.wait();
                             }
                         } catch (InterruptedException err) {
@@ -189,7 +190,7 @@ public class TracksClient {
 
         // This is the thread that sends the request to the server and wait for the response.
         // single network connection model.
-        Thread networkThread = new Thread(new Runnable() {
+        final Thread networkThread = new Thread(new Runnable() {
 
             public void run() {
 
@@ -198,22 +199,18 @@ public class TracksClient {
                     // 1. copy request from the networkQueue queue to a temporary queue and release the lock over the network queue.
                     synchronized (mNetworkQueue) {
                         try {
-                            if (mNetworkQueue.size() == 0) {
+                            while (mNetworkQueue.size() == 0) {
                                 mNetworkQueue.wait();
                             }
-                            // copy the request and release the lock asap
-                            if (mNetworkQueue.size() > 0) {
-                                currentRequest = mNetworkQueue.removeFirst();
-                            }
+                            currentRequest = mNetworkQueue.removeFirst();
                         } catch (InterruptedException err) {
                             Log.e(LOGTAG, "Something went wrong while waiting on the network queue", err);
                         }
                     }
 
-                    if (currentRequest != null) {
-                        boolean isErrorResponse = false;
-                        // send the request
-
+                    boolean isErrorResponse = false;
+                    // send the request if the network is available
+                    if (NetworkUtils.isNetworkAvailable(mContext)) {
                         HttpURLConnection conn = null;
                         try {
                             URL requestURL = new URL(mTracksRestEndpointURL);
@@ -229,21 +226,21 @@ public class TracksClient {
                             conn.setDoOutput(true);
 
                             //Send request
-                            OutputStream wr = conn.getOutputStream ();
+                            OutputStream wr = conn.getOutputStream();
                             wr.write(currentRequest.requestObj.toString().getBytes(PROTOCOL_CHARSET));
                             wr.flush();
-                            wr.close ();
+                            wr.close();
 
                             // Read the request
                             int respCode = conn.getResponseCode();
-                            if (respCode!= HttpURLConnection.HTTP_OK && respCode != HttpURLConnection.HTTP_ACCEPTED) {
+                            if (respCode != HttpURLConnection.HTTP_OK && respCode != HttpURLConnection.HTTP_ACCEPTED) {
                                 isErrorResponse = true;
                                 // read the response of the server in case of errors
                                 InputStream is = conn.getInputStream();
                                 BufferedReader rd = new BufferedReader(new InputStreamReader(is));
                                 String line;
                                 StringBuffer response = new StringBuffer();
-                                while((line = rd.readLine()) != null) {
+                                while ((line = rd.readLine()) != null) {
                                     response.append(line);
                                     response.append('\r');
                                 }
@@ -265,30 +262,37 @@ public class TracksClient {
                                 if (conn != null) {
                                     conn.disconnect();
                                 }
-                            } catch (Exception e){
+                            } catch (Exception e) {
                             }
                             if (isErrorResponse) {
-                                mLastNetworkErrorTimestamp = System.currentTimeMillis();
-                                // Loop on events and keep those events that we must re-enqueue
-                                LinkedList<Event> mustKeepEventsList = new LinkedList<>(); // events we're re-enqueuing
-                                for (Event singleEvent : currentRequest.src) {
-                                    if (isStillValid(singleEvent)) {
-                                        singleEvent.addRetryCount();
-                                        mustKeepEventsList.add(singleEvent);
-                                    }
-                                }
-                                if (mustKeepEventsList.size() > 0) {
-                                    synchronized (mInsertEventsQueue) {
-                                        mInsertEventsQueue.addAll(mustKeepEventsList);
-                                        mInsertEventsQueue.notifyAll();
-                                    }
-                                }
+                                reEnqueueEventsAndSetError(currentRequest);
                             } else {
                                 mLastNetworkErrorTimestamp = 0L;
                             }
                         }
+                    } else {
+                        // No network connection
+                        reEnqueueEventsAndSetError(currentRequest);
                     }
                 } // end-while
+            }
+
+            private void reEnqueueEventsAndSetError(NetworkRequestObject request) {
+                mLastNetworkErrorTimestamp = System.currentTimeMillis();
+                // Loop on events and keep those events that we must re-enqueue
+                LinkedList<Event> mustKeepEventsList = new LinkedList<>(); // events we're re-enqueuing
+                for (Event singleEvent : request.src) {
+                    if (isStillValid(singleEvent)) {
+                        singleEvent.addRetryCount();
+                        mustKeepEventsList.add(singleEvent);
+                    }
+                }
+                if (mustKeepEventsList.size() > 0) {
+                    synchronized (mInsertEventsQueue) {
+                        mInsertEventsQueue.addAll(mustKeepEventsList);
+                        mInsertEventsQueue.notifyAll();
+                    }
+                }
             }
         });
         networkThread.setPriority(Thread.NORM_PRIORITY);
@@ -330,9 +334,6 @@ public class TracksClient {
     }
 
     public void flush() {
-        if (!NetworkUtils.isNetworkAvailable(mContext)) {
-            return;
-        }
         // we need to get the lock over the DB to awake the writing thread, and to be sure the flush is done asap.
         // Since we need the lock over the DB is better to do that in a thread. Otherwise the caller should wait until the DB is ready.
         Thread flushingThread = new Thread(new Runnable() {

--- a/AutomatticTracks/src/main/java/com/automattic/android/tracks/TracksClient.java
+++ b/AutomatticTracks/src/main/java/com/automattic/android/tracks/TracksClient.java
@@ -190,7 +190,7 @@ public class TracksClient {
 
         // This is the thread that sends the request to the server and wait for the response.
         // single network connection model.
-        final Thread networkThread = new Thread(new Runnable() {
+        Thread networkThread = new Thread(new Runnable() {
 
             public void run() {
 


### PR DESCRIPTION
This PR should fix #16 by sending events to the server more often by using a timer, that is triggered also in case of network errors.

> My hypothesis is that the app fails to push events (ie: a network error) when the "on background" event happens, and then the user doesn't reopen the app in the next 5 days. 

This PR also bumps version number to 1.0.5. 

<b>Once this is merged we need to release the new version of the library on Maven</b>