### PR TITLE
Add a User Type for Simplenote

### DIFF
--- a/AutomatticTracks/src/main/java/com/automattic/android/tracks/MessageBuilder.java
+++ b/AutomatticTracks/src/main/java/com/automattic/android/tracks/MessageBuilder.java
@@ -105,8 +105,8 @@ class MessageBuilder {
                 eventJSON.put(USER_TYPE_KEY, USER_TYPE_ANON);
                 eventJSON.put(USER_ID_KEY, event.getUser());
             } else {
+                eventJSON.put(USER_TYPE_KEY, event.getUserType().name().toLowerCase());
                 eventJSON.put(USER_LOGIN_NAME_KEY, event.getUser());
-                // no need to put the user type key here. default wpcom is used on the server. 'wpcom:user_id'
             }
 
             unfolderPropertiesNotAvailableInCommon(event.getUserProperties(), USER_INFO_PREFIX, eventJSON, commonProps);

--- a/AutomatticTracks/src/main/java/com/automattic/android/tracks/MessageBuilder.java
+++ b/AutomatticTracks/src/main/java/com/automattic/android/tracks/MessageBuilder.java
@@ -102,16 +102,18 @@ class MessageBuilder {
             }
 
             eventJSON.put(EVENT_TIMESTAMP_KEY, event.getTimeStamp());
-            eventJSON.put(USER_ID_KEY, event.getUser());
 
             switch (event.getUserType()) {
                 case ANON:
+                    eventJSON.put(USER_ID_KEY, event.getUser());
                     eventJSON.put(USER_TYPE_KEY, USER_TYPE_ANON);
                     break;
                 case WPCOM:
+                    eventJSON.put(USER_LOGIN_NAME_KEY, event.getUser());
                     eventJSON.put(USER_TYPE_KEY, USER_TYPE_WPCOM);
                     break;
                 case SIMPLENOTE:
+                    eventJSON.put(USER_LOGIN_NAME_KEY, event.getUser());
                     eventJSON.put(USER_TYPE_KEY, USER_TYPE_SIMPLENOTE);
             }
 

--- a/AutomatticTracks/src/main/java/com/automattic/android/tracks/MessageBuilder.java
+++ b/AutomatticTracks/src/main/java/com/automattic/android/tracks/MessageBuilder.java
@@ -19,8 +19,8 @@ class MessageBuilder {
     private static final String REQUEST_TIMESTAMP_KEY = "_rt";
     private static final String USER_TYPE_KEY = "_ut";
     private static final String USER_TYPE_ANON = "anon";
-    private static final String USER_TYPE_WPCOM = "wpcom:user:id";
-    private static final String USER_TYPE_SIMPLENOTE = "simplenote";
+    private static final String USER_TYPE_WPCOM = "wpcom:user_id";
+    private static final String USER_TYPE_SIMPLENOTE = "simplenote:user_id";
     private static final String USER_ID_KEY = "_ui";
     private static final String USER_LANG_KEY = "_lg";
     private static final String USER_LOGIN_NAME_KEY = "_ul";

--- a/AutomatticTracks/src/main/java/com/automattic/android/tracks/MessageBuilder.java
+++ b/AutomatticTracks/src/main/java/com/automattic/android/tracks/MessageBuilder.java
@@ -18,7 +18,9 @@ class MessageBuilder {
     private static final String EVENT_TIMESTAMP_KEY = "_ts";
     private static final String REQUEST_TIMESTAMP_KEY = "_rt";
     private static final String USER_TYPE_KEY = "_ut";
-    private static final String USER_TYPE_ANON= "anon";
+    private static final String USER_TYPE_ANON = "anon";
+    private static final String USER_TYPE_WPCOM = "wpcom:user:id";
+    private static final String USER_TYPE_SIMPLENOTE = "simplenote";
     private static final String USER_ID_KEY = "_ui";
     private static final String USER_LANG_KEY = "_lg";
     private static final String USER_LOGIN_NAME_KEY = "_ul";
@@ -100,13 +102,17 @@ class MessageBuilder {
             }
 
             eventJSON.put(EVENT_TIMESTAMP_KEY, event.getTimeStamp());
+            eventJSON.put(USER_ID_KEY, event.getUser());
 
-            if (event.getUserType() == TracksClient.NosaraUserType.ANON) {
-                eventJSON.put(USER_TYPE_KEY, USER_TYPE_ANON);
-                eventJSON.put(USER_ID_KEY, event.getUser());
-            } else {
-                eventJSON.put(USER_TYPE_KEY, event.getUserType().name().toLowerCase());
-                eventJSON.put(USER_LOGIN_NAME_KEY, event.getUser());
+            switch (event.getUserType()) {
+                case ANON:
+                    eventJSON.put(USER_TYPE_KEY, USER_TYPE_ANON);
+                    break;
+                case WPCOM:
+                    eventJSON.put(USER_TYPE_KEY, USER_TYPE_WPCOM);
+                    break;
+                case SIMPLENOTE:
+                    eventJSON.put(USER_TYPE_KEY, USER_TYPE_SIMPLENOTE);
             }
 
             unfolderPropertiesNotAvailableInCommon(event.getUserProperties(), USER_INFO_PREFIX, eventJSON, commonProps);

--- a/AutomatticTracks/src/main/java/com/automattic/android/tracks/TracksClient.java
+++ b/AutomatticTracks/src/main/java/com/automattic/android/tracks/TracksClient.java
@@ -35,7 +35,7 @@ public class TracksClient {
     protected static final int DEFAULT_EVENTS_QUEUE_THRESHOLD = 9;
     protected static final int DEFAULT_EVENTS_QUEUE_TIMER_MS = 30000;
 
-    public static enum NosaraUserType {ANON, WPCOM}
+    public static enum NosaraUserType {ANON, WPCOM, SIMPLENOTE}
 
     /**
      * Socket timeout in milliseconds for rest requests


### PR DESCRIPTION
Added `SIMPLENOTE` to the user type enum, and changed the message builder to always send the user type in lower case. 

I'm concerned I might have broken WPAndroid reporting, but it looks like it sets the user type to `WPCOM` anyways.

Idea for the future: maybe the library should allow clients to set the type string themselves?

@daniloercoli needs review!