### PR TITLE
Fix crash while accessing BT on 4.x

### DIFF
--- a/AutomatticTracks/build.gradle
+++ b/AutomatticTracks/build.gradle
@@ -25,7 +25,7 @@ android {
     buildToolsVersion "23.0.1"
 
     defaultConfig {
-        versionName "1.0.6"
+        versionName "1.1.0"
         minSdkVersion 14
         targetSdkVersion 22
     }

--- a/AutomatticTracks/src/main/java/com/automattic/android/tracks/DeviceInformation.java
+++ b/AutomatticTracks/src/main/java/com/automattic/android/tracks/DeviceInformation.java
@@ -242,6 +242,12 @@ import java.util.Locale;
     }
 
     public Boolean isBluetoothEnabled() {
+        // Do not retrieve bluetooth info on older Android versions.
+        // See: https://github.com/Automattic/Automattic-Tracks-Android/issues/20
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
+            return null;
+        }
+
         Boolean isBluetoothEnabled = null;
         if (PackageManager.PERMISSION_GRANTED == mContext.checkCallingOrSelfPermission(Manifest.permission.BLUETOOTH)) {
             BluetoothAdapter bluetoothAdapter = BluetoothAdapter.getDefaultAdapter();

--- a/AutomatticTracks/src/main/java/com/automattic/android/tracks/DeviceInformation.java
+++ b/AutomatticTracks/src/main/java/com/automattic/android/tracks/DeviceInformation.java
@@ -243,13 +243,11 @@ import java.util.Locale;
 
     public Boolean isBluetoothEnabled() {
         Boolean isBluetoothEnabled = null;
-        try {
+        if (PackageManager.PERMISSION_GRANTED == mContext.checkCallingOrSelfPermission(Manifest.permission.BLUETOOTH)) {
             BluetoothAdapter bluetoothAdapter = BluetoothAdapter.getDefaultAdapter();
             if (bluetoothAdapter != null) {
                 isBluetoothEnabled = bluetoothAdapter.isEnabled();
             }
-        } catch (SecurityException e) {
-            // do nothing since we don't have permissions
         }
         return isBluetoothEnabled;
     }

--- a/AutomatticTracks/src/main/java/com/automattic/android/tracks/TracksClient.java
+++ b/AutomatticTracks/src/main/java/com/automattic/android/tracks/TracksClient.java
@@ -309,17 +309,23 @@ public class TracksClient {
         final String packageName = context.getPackageName();
 
         if (PackageManager.PERMISSION_GRANTED != packageManager.checkPermission("android.permission.INTERNET", packageName)) {
-            Log.w(LOGTAG, "Package does not have permission android.permission.INTERNET - Nosara Client will not work at all!");
-            Log.i(LOGTAG, "You can fix this by adding the following to your AndroidManifest.xml file:\n" +
+            Log.e(LOGTAG, "Package does not have permission android.permission.INTERNET - Nosara Client will not work at all!");
+            Log.w(LOGTAG, "You can fix this by adding the following to your AndroidManifest.xml file:\n" +
                     "<uses-permission android:name=\"android.permission.INTERNET\" />");
             return false;
         }
 
         if (PackageManager.PERMISSION_GRANTED != packageManager.checkPermission("android.permission.ACCESS_NETWORK_STATE", packageName)) {
-            Log.w(LOGTAG, "Package does not have permission android.permission.ACCESS_NETWORK_STATE - Nosara Client will not work at all!");
-            Log.i(LOGTAG, "You can fix this by adding the following to your AndroidManifest.xml file:\n" +
+            Log.e(LOGTAG, "Package does not have permission android.permission.ACCESS_NETWORK_STATE - Nosara Client will not work at all!");
+            Log.w(LOGTAG, "You can fix this by adding the following to your AndroidManifest.xml file:\n" +
                     "<uses-permission android:name=\"android.permission.ACCESS_NETWORK_STATE\" />");
             return false;
+        }
+
+        if (PackageManager.PERMISSION_GRANTED != packageManager.checkPermission("android.permission.BLUETOOTH", packageName)) {
+            Log.w(LOGTAG, "Package does not have permission android.permission.BLUETOOTH - Nosara Client will not report BT state");
+            Log.w(LOGTAG, "You can fix this by adding the following to your AndroidManifest.xml file:\n" +
+                    "<uses-permission android:name=\"android.permission.BLUETOOTH\" />");
         }
 
         return true;


### PR DESCRIPTION
Fix #20 and bump version number to 1.1

Once this is merged we need to publish it on Sonatype.

cc /@maxme
@roundhill  - This is the version you need to use in Simplenote.
