### PR TITLE
Fix null event names and event properties 

### DIFF
--- a/AutomatticTracks/build.gradle
+++ b/AutomatticTracks/build.gradle
@@ -24,9 +24,9 @@ android {
     buildToolsVersion "25.0.2"
 
     defaultConfig {
-        versionName "1.1.1"
+        versionName "1.1.2"
         minSdkVersion 14
-        targetSdkVersion 24
+        targetSdkVersion 25
     }
 
     compileOptions {

--- a/AutomatticTracks/build.gradle
+++ b/AutomatticTracks/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.2'
+        classpath 'com.android.tools.build:gradle:2.3.1'
         classpath 'com.novoda:bintray-release:0.3.4'
     }
 }
@@ -20,8 +20,8 @@ dependencies {
 }
 
 android {
-    compileSdkVersion 24
-    buildToolsVersion "23.0.3"
+    compileSdkVersion 25
+    buildToolsVersion "25.0.2"
 
     defaultConfig {
         versionName "1.1.1"

--- a/AutomatticTracks/src/main/java/com/automattic/android/tracks/Event.java
+++ b/AutomatticTracks/src/main/java/com/automattic/android/tracks/Event.java
@@ -3,6 +3,7 @@ package com.automattic.android.tracks;
 import android.text.TextUtils;
 import android.util.Log;
 
+import com.automattic.android.tracks.Exceptions.EventDetailsException;
 import com.automattic.android.tracks.Exceptions.EventNameException;
 
 import org.json.JSONException;
@@ -34,12 +35,25 @@ public class Event implements Serializable {
     private JSONObject mCustomEventProps;
 
     public Event(String mEventName, String userID, TracksClient.NosaraUserType uType,
-                 String userAgent, long timeStamp) throws EventNameException {
+                 String userAgent, long timeStamp) throws EventNameException, EventDetailsException {
+
         checkEventName(mEventName);
+        if (TextUtils.isEmpty(userID)) {
+            throw new EventDetailsException("Username cannot be empty!");
+        }
+
+        if (uType == null) {
+            throw new EventDetailsException("NosaraUserType cannot be null!");
+        }
+
+        if (TextUtils.isEmpty(userAgent)) {
+            Log.w(LOGTAG, "User Agent string is empty!");
+        }
+
         this.mEventName = mEventName;
         this.mUser = userID;
         this.mUserType = uType;
-        this.mUserAgent = userAgent;
+        this.mUserAgent = StringUtils.notNullStr(userAgent);
         this.mTimeStamp = timeStamp;
     }
 

--- a/AutomatticTracks/src/main/java/com/automattic/android/tracks/Event.java
+++ b/AutomatticTracks/src/main/java/com/automattic/android/tracks/Event.java
@@ -1,5 +1,6 @@
 package com.automattic.android.tracks;
 
+import android.text.TextUtils;
 import android.util.Log;
 
 import com.automattic.android.tracks.Exceptions.EventNameException;
@@ -46,6 +47,10 @@ public class Event implements Serializable {
         if (name.equals(MessageBuilder.ALIAS_USER_EVENT_NAME)) {
             // "_aliasUser is a special case. No validation on it.
             return;
+        }
+
+        if (TextUtils.isEmpty(name)) {
+            throw new EventNameException("Event name must not ne empty or null");
         }
 
         if (name.contains("-")) {

--- a/AutomatticTracks/src/main/java/com/automattic/android/tracks/Exceptions/EventDetailsException.java
+++ b/AutomatticTracks/src/main/java/com/automattic/android/tracks/Exceptions/EventDetailsException.java
@@ -1,0 +1,7 @@
+package com.automattic.android.tracks.Exceptions;
+
+public class EventDetailsException extends Exception {
+    public EventDetailsException(String detailMessage) {
+        super(detailMessage);
+    }
+}

--- a/AutomatticTracks/src/main/java/com/automattic/android/tracks/StringUtils.java
+++ b/AutomatticTracks/src/main/java/com/automattic/android/tracks/StringUtils.java
@@ -42,4 +42,13 @@ public class StringUtils {
         return false;
     }
 
+    /*
+     * returns empty string if passed string is null, otherwise returns passed string
+     */
+    public static String notNullStr(String s) {
+        if (s == null) {
+            return "";
+        }
+        return s;
+    }
 }

--- a/AutomatticTracks/src/main/java/com/automattic/android/tracks/TracksClient.java
+++ b/AutomatticTracks/src/main/java/com/automattic/android/tracks/TracksClient.java
@@ -5,6 +5,7 @@ import android.content.pm.PackageManager;
 import android.os.Handler;
 import android.util.Log;
 
+import com.automattic.android.tracks.Exceptions.EventDetailsException;
 import com.automattic.android.tracks.Exceptions.EventNameException;
 import com.automattic.android.tracks.datasets.EventTable;
 
@@ -368,7 +369,7 @@ public class TracksClient {
     }
 
     public void track(String eventName, JSONObject customProps, String user, NosaraUserType userType) {
-        Event event = null;
+        Event event;
         try {
             event = new Event(
                     eventName,
@@ -377,7 +378,7 @@ public class TracksClient {
                     getUserAgent(),
                     System.currentTimeMillis()
             );
-        } catch (EventNameException e) {
+        } catch (EventNameException | EventDetailsException e) {
             Log.e(LOGTAG, "Cannot create the event: " +eventName, e);
             return;
         }

--- a/AutomatticTracks/src/main/java/com/automattic/android/tracks/datasets/EventTable.java
+++ b/AutomatticTracks/src/main/java/com/automattic/android/tracks/datasets/EventTable.java
@@ -102,7 +102,7 @@ public class EventTable {
             stmt.execute();
 
             db.setTransactionSuccessful();
-        } catch(IllegalArgumentException e) {
+        } catch (IllegalArgumentException e) {
             Log.e(TracksDatabaseHelper.LOGTAG, "Cannot insert the current event. Please check the details of the event!", e);
         } finally {
             db.endTransaction();

--- a/AutomatticTracks/src/main/java/com/automattic/android/tracks/datasets/EventTable.java
+++ b/AutomatticTracks/src/main/java/com/automattic/android/tracks/datasets/EventTable.java
@@ -77,7 +77,7 @@ public class EventTable {
             stmt.bindString(1, event.getEventName());
             stmt.bindString(2, event.getUser());
             stmt.bindString(3, event.getUserAgent());
-            stmt.bindLong(4,  event.getUserType().ordinal());
+            stmt.bindLong(4, event.getUserType().ordinal());
 
             if (event.getUserProperties() != null) {
                 stmt.bindString(5, event.getUserProperties().toString());
@@ -97,11 +97,13 @@ public class EventTable {
             }
 
             stmt.bindLong(8, event.getTimeStamp());
-            stmt.bindLong(9,  event.getRetryCount());
+            stmt.bindLong(9, event.getRetryCount());
 
             stmt.execute();
 
             db.setTransactionSuccessful();
+        } catch(IllegalArgumentException e) {
+            Log.e(TracksDatabaseHelper.LOGTAG, "Cannot insert the current event. Please check the details of the event!", e);
         } finally {
             db.endTransaction();
             SqlUtils.closeStatement(stmt);


### PR DESCRIPTION
This PR fix an issue where passing an empty user to the library generates a bad crash.
I've also added other checks over the properties passed to the event, so the library should not crash if an invalid input is given.

- Also modernized gradle, and SDK.

Version number is also bumped, so we can release a new version of the library when this is merged to develop.

cc @maxme 