### PR TITLE
NPE ConnectivityManager

### DIFF
--- a/AutomatticTracks/src/main/java/com/automattic/android/tracks/DeviceInformation.java
+++ b/AutomatticTracks/src/main/java/com/automattic/android/tracks/DeviceInformation.java
@@ -228,14 +228,20 @@ import java.util.Locale;
         return ret;
     }
 
-
     public Boolean isWifiConnected() {
-        Boolean ret = null;
+        Boolean ret = Boolean.FALSE;
 
         if (PackageManager.PERMISSION_GRANTED == mContext.checkCallingOrSelfPermission(Manifest.permission.ACCESS_NETWORK_STATE)) {
             ConnectivityManager connManager = (ConnectivityManager) this.mContext.getSystemService(Context.CONNECTIVITY_SERVICE);
-            NetworkInfo wifiInfo = connManager.getNetworkInfo(ConnectivityManager.TYPE_WIFI);
-            ret = wifiInfo.isConnected();
+            if (connManager != null) {
+                try {
+                    NetworkInfo wifiInfo = connManager.getNetworkInfo(ConnectivityManager.TYPE_WIFI);
+                    ret = wifiInfo != null && wifiInfo.isConnected();
+                } catch (NullPointerException e) {
+                    Log.e(LOGTAG, "Cannot access WI-FI status", e);
+                    // See: https://github.com/Automattic/Automattic-Tracks-Android/issues/29
+                }
+            }
         }
 
         return ret;


### PR DESCRIPTION
Fix #29 by making sure ConnectivityManager is not null before asking for details. 
Also added a try/catch block that should help catching the internal ConnectivityManager null-pointer exception and don't crash the app.