### PR TITLE
Discard > 14 days old events, and set a limit of 10.000 items over the events queue

### DIFF
--- a/AutomatticTracks/build.gradle
+++ b/AutomatticTracks/build.gradle
@@ -3,8 +3,8 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.1'
-        classpath 'com.novoda:bintray-release:0.3.4'
+        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.novoda:bintray-release:0.5.0'
     }
 }
 
@@ -20,8 +20,8 @@ dependencies {
 }
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.2"
+    compileSdkVersion 26
+    buildToolsVersion "26.0.2"
 
     defaultConfig {
         versionName "1.1.3"

--- a/AutomatticTracks/src/main/java/com/automattic/android/tracks/TracksClient.java
+++ b/AutomatticTracks/src/main/java/com/automattic/android/tracks/TracksClient.java
@@ -111,6 +111,7 @@ public class TracksClient {
                         //2.  get the lock over the DB and write data
                         synchronized (mDbLock) {
                             // do not write events if the queue is already full
+                            // TODO: Remove older events and insert the new ones - See https://github.com/Automattic/Automattic-Tracks-Android/pull/35#discussion_r172458380
                             if (EventTable.getEventsCount(mContext) < DEFAULT_EVENTS_QUEUE_MAX_SIZE) {
                                 for (Event currentEvent : shadowCopyEventList) {
                                     EventTable.insertEvent(mContext, currentEvent);

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip


### PR DESCRIPTION
This PR fixes #33 and #34 by making sure events are still valid before sending it to the server, and prevents possible floods of events sent to the server by setting a limit of 10.000 over the events queue.


CC @malinajirka and @khaykov  - Since you were the latest persons to work on the library since long time