### PR TITLE
Log device orientation + bump version to 1.1.5

### DIFF
--- a/AutomatticTracks/build.gradle
+++ b/AutomatticTracks/build.gradle
@@ -1,5 +1,6 @@
 buildscript {
     repositories {
+        google()
         jcenter()
     }
     dependencies {

--- a/AutomatticTracks/build.gradle
+++ b/AutomatticTracks/build.gradle
@@ -25,7 +25,7 @@ android {
     buildToolsVersion "26.0.2"
 
     defaultConfig {
-        versionName "1.1.4"
+        versionName "1.1.5"
         minSdkVersion 14
         targetSdkVersion 25
     }

--- a/AutomatticTracks/src/main/java/com/automattic/android/tracks/DeviceInformation.java
+++ b/AutomatticTracks/src/main/java/com/automattic/android/tracks/DeviceInformation.java
@@ -40,6 +40,9 @@ import java.util.Locale;
 
 /* package */ class DeviceInformation {
     public static final String LOGTAG = "NosaraDeviceInformation";
+    private static final String ORIENTATION_PORTRAIT = "portrait";
+    private static final String ORIENTATION_LANDSCAPE = "landscape";
+
     private static final int DISPLAY_SIZE_LARGE_THRESHOLD = 7;
 
     private final Context mContext;
@@ -231,9 +234,9 @@ import java.util.Locale;
         int currentRotation = getCurrentRotation();
 
         if (currentRotation == Surface.ROTATION_0 || currentRotation == Surface.ROTATION_180) {
-            return mIsPortraitDefault ? "Portrait" : "Landscape";
+            return mIsPortraitDefault ? ORIENTATION_PORTRAIT : ORIENTATION_LANDSCAPE;
         } else {
-            return mIsPortraitDefault ? "Landscape" : "Portrait";
+            return mIsPortraitDefault ? ORIENTATION_LANDSCAPE : ORIENTATION_PORTRAIT;
         }
     }
 

--- a/AutomatticTracks/src/main/java/com/automattic/android/tracks/DeviceInformation.java
+++ b/AutomatticTracks/src/main/java/com/automattic/android/tracks/DeviceInformation.java
@@ -7,6 +7,7 @@ import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.content.pm.PackageManager.NameNotFoundException;
+import android.content.res.Configuration;
 import android.graphics.Point;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
@@ -16,6 +17,7 @@ import android.text.TextUtils;
 import android.util.DisplayMetrics;
 import android.util.Log;
 import android.view.Display;
+import android.view.Surface;
 import android.view.View;
 import android.view.WindowManager;
 
@@ -55,6 +57,7 @@ import java.util.Locale;
     private int mHeightPixels;
 
     private final JSONObject mImmutableDeviceInfoJSON;
+    private final boolean mIsPortraitDefault;
 
     public DeviceInformation(Context context) {
         mContext = context;
@@ -90,6 +93,8 @@ import java.util.Locale;
         // We're caching device's language here, even if the user can change it while the app is running.
         mLocale = Locale.getDefault();
         mDeviceLanguage = mLocale.toString();
+        mIsPortraitDefault =
+                mContext.getResources().getConfiguration().orientation == Configuration.ORIENTATION_PORTRAIT;
 
         // We can't count on these features being available, since we need to
         // run on old devices. Thus, the reflection fandango below...
@@ -215,7 +220,24 @@ import java.util.Locale;
             Log.e(LOGTAG, "Exception writing network info values in JSON object", e);
         }
 
+        try {
+            mutableDeviceInfo.put("device_orientation", getDeviceOrientation());
+        } catch (final JSONException e) {
+            Log.e(LOGTAG, "Exception writing device orientation info value in JSON object", e);
+        }
+
         return mutableDeviceInfo;
+    }
+
+    private String getDeviceOrientation() {
+        int currentRotation =
+                ((WindowManager) mContext.getSystemService(Context.WINDOW_SERVICE)).getDefaultDisplay().getRotation();
+
+        if (currentRotation == Surface.ROTATION_0 || currentRotation == Surface.ROTATION_180) {
+            return mIsPortraitDefault ? "Portrait" : "Landscape";
+        } else {
+            return mIsPortraitDefault ? "Landscape" : "Portrait";
+        }
     }
 
     public JSONObject getImmutableDeviceInfo() {

--- a/AutomatticTracks/src/main/java/com/automattic/android/tracks/DeviceInformation.java
+++ b/AutomatticTracks/src/main/java/com/automattic/android/tracks/DeviceInformation.java
@@ -93,8 +93,7 @@ import java.util.Locale;
         // We're caching device's language here, even if the user can change it while the app is running.
         mLocale = Locale.getDefault();
         mDeviceLanguage = mLocale.toString();
-        mIsPortraitDefault =
-                mContext.getResources().getConfiguration().orientation == Configuration.ORIENTATION_PORTRAIT;
+        mIsPortraitDefault = isPortraitDefault();
 
         // We can't count on these features being available, since we need to
         // run on old devices. Thus, the reflection fandango below...
@@ -202,7 +201,6 @@ import java.util.Locale;
         }
     }
 
-
     // Returns those system info that could change upon time.
     public JSONObject getMutableDeviceInfo() {
         JSONObject mutableDeviceInfo = new JSONObject();
@@ -230,14 +228,25 @@ import java.util.Locale;
     }
 
     private String getDeviceOrientation() {
-        int currentRotation =
-                ((WindowManager) mContext.getSystemService(Context.WINDOW_SERVICE)).getDefaultDisplay().getRotation();
+        int currentRotation = getCurrentRotation();
 
         if (currentRotation == Surface.ROTATION_0 || currentRotation == Surface.ROTATION_180) {
             return mIsPortraitDefault ? "Portrait" : "Landscape";
         } else {
             return mIsPortraitDefault ? "Landscape" : "Portrait";
         }
+    }
+
+    private boolean isPortraitDefault() {
+        int currentRotation = getCurrentRotation();
+        return (mContext.getResources().getConfiguration().orientation == Configuration.ORIENTATION_PORTRAIT
+                && (currentRotation == Surface.ROTATION_0 || currentRotation == Surface.ROTATION_180))
+               || (mContext.getResources().getConfiguration().orientation == Configuration.ORIENTATION_LANDSCAPE
+                   && ((currentRotation == Surface.ROTATION_90 || currentRotation == Surface.ROTATION_270)));
+    }
+
+    private int getCurrentRotation() {
+        return ((WindowManager) mContext.getSystemService(Context.WINDOW_SERVICE)).getDefaultDisplay().getRotation();
     }
 
     public JSONObject getImmutableDeviceInfo() {


### PR DESCRIPTION
Fixes #39

- adds `google()` repository to build.gradle
- adds device orientation property to immutableProperties
- bumps version to 1.1.5

`getConfiguration().orientation` may get out of sync. Therefore we use it only when the app starts to find out whether the natural (default) device orientation is portrait/landscape. The current device orientation is derived from `rotation`.

To test:
I'm not sure whether there is an easy way how to test this. I've added a log to DeviceInformation and published an artifact to local maven repository.

Note: We need to publish the new artifact to bintray.