### PR TITLE
Upgrade Gradle and Plugin

### DIFF
--- a/AutomatticTracks/build.gradle
+++ b/AutomatticTracks/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.android.tools.build:gradle:3.3.1'
         classpath 'com.novoda:bintray-release:0.5.0'
     }
 }
@@ -22,7 +22,7 @@ dependencies {
 
 android {
     compileSdkVersion 26
-    buildToolsVersion "26.0.2"
+    buildToolsVersion "28.0.3"
 
     defaultConfig {
         versionName "1.1.5"

--- a/AutomatticTracks/build.gradle
+++ b/AutomatticTracks/build.gradle
@@ -24,7 +24,6 @@ dependencies {
 
 android {
     compileSdkVersion 26
-    buildToolsVersion "28.0.3"
 
     defaultConfig {
         versionName "1.1.5"

--- a/AutomatticTracks/build.gradle
+++ b/AutomatticTracks/build.gradle
@@ -16,7 +16,6 @@ apply plugin: 'com.novoda.bintray-release'
 repositories {
     google()
     jcenter()
-    mavenCentral()
 }
 
 dependencies {

--- a/AutomatticTracks/build.gradle
+++ b/AutomatticTracks/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.3.1'
-        classpath 'com.novoda:bintray-release:0.5.0'
+        classpath 'com.novoda:bintray-release:0.8.1'
     }
 }
 
@@ -43,7 +43,7 @@ publish {
     groupId = 'com.automattic'
     uploadName = 'tracks'
     artifactId = 'tracks'
-    description = 'Android client for Nosara tracks (event tracking and analytics)'
+    desc = 'Android client for Nosara tracks (event tracking and analytics)'
     publishVersion = android.defaultConfig.versionName
     licences = ['MIT']
     website = 'https://github.com/Automattic/Automattic-Tracks-Android'

--- a/AutomatticTracks/build.gradle
+++ b/AutomatticTracks/build.gradle
@@ -14,6 +14,8 @@ apply plugin: 'maven'
 apply plugin: 'com.novoda.bintray-release'
 
 repositories {
+    google()
+    jcenter()
     mavenCentral()
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Apr 14 17:18:20 CEST 2017
+#Thu Feb 14 14:07:57 MST 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip


### PR DESCRIPTION
While working on wordpress-mobile/WordPress-Android#9253, I was blocked by not being able to build this project on Android Studio 3.3. 

## Sync

The Gradle sync fails with this error:

```
No toolchains found in the NDK toolchains folder for ABI with prefix: mips64el-linux-android
```

Upgrading Gradle and the Android plugin fixes the sync.

## Unresolved dependency

Added google and jcenter to repositories to fix this error when trying to run `./gradlew assemble`

```
Could not resolve all files for configuration ':AutomatticTracks:_internal_aapt2_binary'.
Could not find com.android.tools.build:aapt2:3.3.1-5013011.
```

It looks like aapt2 has been [relocated to `google()`](https://developer.android.com/studio/releases/#aapt2_gmaven). Interestingly, the build will not work without `jcenter()` too. I’m not sure why.

## Not handled by this PR

This error shows up when syncing but it does to seem to be too urgent to fix right now. 

```
WARNING: API 'variant.getJavaCompile()' is obsolete and has been replaced with 'variant.getJavaCompileProvider()'.
It will be removed at the end of 2019.
For more information, see https://d.android.com/r/tools/task-configuration-avoidance.
To determine what is calling variant.getJavaCompile(), use -Pandroid.debug.obsoleteApi=true on the command line to display a stack trace.
Affected Modules: AutomatticTracks
```

I also have no idea how to fix it. 🤷‍♂️ 