### PR TITLE
Add is_online to event properties

### DIFF
--- a/AutomatticTracks/build.gradle
+++ b/AutomatticTracks/build.gradle
@@ -27,7 +27,7 @@ android {
     buildToolsVersion "28.0.3"
 
     defaultConfig {
-        versionName "1.1.5"
+        versionName "1.1.6"
         minSdkVersion 14
         targetSdkVersion 25
     }

--- a/AutomatticTracks/build.gradle
+++ b/AutomatticTracks/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.3.1'
-        classpath 'com.novoda:bintray-release:0.5.0'
+        classpath 'com.novoda:bintray-release:0.8.1'
     }
 }
 
@@ -44,7 +44,7 @@ publish {
     groupId = 'com.automattic'
     uploadName = 'tracks'
     artifactId = 'tracks'
-    description = 'Android client for Nosara tracks (event tracking and analytics)'
+    desc = 'Android client for Nosara tracks (event tracking and analytics)'
     publishVersion = android.defaultConfig.versionName
     licences = ['MIT']
     website = 'https://github.com/Automattic/Automattic-Tracks-Android'

--- a/AutomatticTracks/src/main/java/com/automattic/android/tracks/DeviceInformation.java
+++ b/AutomatticTracks/src/main/java/com/automattic/android/tracks/DeviceInformation.java
@@ -1,6 +1,7 @@
 package com.automattic.android.tracks;
 
 import android.Manifest;
+import android.annotation.SuppressLint;
 import android.bluetooth.BluetoothAdapter;
 import android.content.Context;
 import android.content.pm.ApplicationInfo;
@@ -217,6 +218,7 @@ import java.util.Locale;
             mutableDeviceInfo.put("current_network_operator", getCurrentNetworkOperator());
             mutableDeviceInfo.put("phone_radio_type", getPhoneRadioType()); // NONE - GMS - CDMA - SIP
             mutableDeviceInfo.put("wifi_connected", isWifiConnected());
+            mutableDeviceInfo.put("is_online", isOnline());
         } catch (final JSONException e) {
             Log.e(LOGTAG, "Exception writing network info values in JSON object", e);
         }
@@ -324,6 +326,18 @@ import java.util.Locale;
         }
 
         return ret;
+    }
+
+    private Boolean isOnline() {
+        if (PackageManager.PERMISSION_GRANTED != mContext.checkCallingOrSelfPermission(Manifest.permission.ACCESS_NETWORK_STATE)) {
+            return false;
+        }
+
+        ConnectivityManager manager = (ConnectivityManager) mContext.getSystemService(Context.CONNECTIVITY_SERVICE);
+        @SuppressLint("MissingPermission")
+        NetworkInfo networkInfo = manager != null ? manager.getActiveNetworkInfo() : null;
+
+        return networkInfo != null && networkInfo.isConnectedOrConnecting();
     }
 
     public Boolean isBluetoothEnabled() {


### PR DESCRIPTION
**Notice**: This PR depends on #43 to be merged first. 

This is part of wordpress-mobile/WordPress-Android#9253. The next step is linking the version of this PR (**1.1.6**) in WordPress-Android. 

 ## Testing

This can be tested by using this library directly in WordPress-Android.

1. Set this up as a local dependency in WordPress-Android as a local Maven artifact or a local project like in this [gist](https://gist.github.com/shiki/7d850e0a637b86e3738d5f3a030600eb). 
2. Run the WordPress-Android app. 
3. Play around with the app while offline so events are logged. 
4. Check the logged events of your WordPress account in Tracks Live View. Pick one event and validate that it has a `device_info_is_online` property. Please note that it takes a while for Tracks to display the logged events.

We probably won't be able to test this with Tracks Trends until the next day (p4qSXL-2Yz-p2) so the Tracks Live View is what we can test for now.