### PR TITLE
Upgrade bintray-release to 0.9

### DIFF
--- a/AutomatticTracks/build.gradle
+++ b/AutomatticTracks/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.3.1'
-        classpath 'com.novoda:bintray-release:0.8.1'
+        classpath 'com.novoda:bintray-release:0.9'
     }
 }
 


### PR DESCRIPTION
This version has fixes for Android projects using Gradle 4.5+.

Tested with `./gradlew clean assemble publishToMavenLocal`. Seems to work fine. 