### PR TITLE
Add Sentry support

### DIFF
--- a/AutomatticTracks/build.gradle
+++ b/AutomatticTracks/build.gradle
@@ -19,6 +19,8 @@ repositories {
 }
 
 dependencies {
+    implementation 'io.sentry:sentry-android:1.7.16'
+    implementation 'org.jetbrains:annotations-java5:15.0'
 }
 
 android {

--- a/AutomatticTracks/src/main/java/com/automattic/android/tracks/CrashLogging/CrashLogging.java
+++ b/AutomatticTracks/src/main/java/com/automattic/android/tracks/CrashLogging/CrashLogging.java
@@ -1,0 +1,138 @@
+package com.automattic.android.tracks.CrashLogging;
+
+import android.content.Context;
+import android.util.Log;
+
+import com.automattic.android.tracks.BuildConfig;
+import com.automattic.android.tracks.TracksUser;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Locale;
+import java.util.Map;
+
+import io.sentry.Sentry;
+import io.sentry.SentryClient;
+import io.sentry.android.AndroidSentryClientFactory;
+import io.sentry.connection.EventSendCallback;
+import io.sentry.event.Event;
+import io.sentry.event.EventBuilder;
+import io.sentry.event.UserBuilder;
+import io.sentry.event.helper.ShouldSendEventCallback;
+import io.sentry.event.interfaces.ExceptionInterface;
+
+public class CrashLogging {
+
+    private static CrashLoggingDataProvider mDataProvider;
+    private static SentryClient sentry;
+
+    public static void start(Context context, CrashLoggingDataProvider dataProvider) {
+
+        sentry = Sentry.init(
+                dataProvider.sentryDSN(),
+                new AndroidSentryClientFactory(context)
+        );
+
+        // Apply Sentry Tags
+        sentry.setEnvironment(dataProvider.buildType());
+        sentry.setRelease(dataProvider.releaseName());
+        sentry.addTag("locale", getCurrentLanguage(dataProvider.locale()));
+
+        sentry.addShouldSendEventCallback(new ShouldSendEventCallback() {
+            @Override
+            public boolean shouldSend(Event event) {
+
+                if (BuildConfig.DEBUG) {
+                    return false;
+                }
+
+                return !mDataProvider.getUserHasOptedOut();
+            }
+        });
+
+        sentry.addEventSendCallback(new EventSendCallback() {
+            @Override
+            public void onFailure(Event event, Exception exception) {
+                Log.println(Log.WARN, "SENTRY", exception.getLocalizedMessage());
+            }
+
+            @Override
+            public void onSuccess(Event event) {
+                Log.println(Log.INFO, "SENTRY", event.getMessage());
+            }
+        });
+
+        mDataProvider = dataProvider;
+        applyUserTrackingPreferences();
+    }
+
+    public static void crash() {
+        throw new UnsupportedOperationException("This is a sample crash");
+    }
+
+    public static boolean getUserHasOptedOut() {
+        return mDataProvider.getUserHasOptedOut();
+    }
+
+    public static void setUserHasOptedOut(boolean userHasOptedOut) {
+        mDataProvider.setUserHasOptedOut(userHasOptedOut);
+        applyUserTrackingPreferences();
+    }
+
+    private static void applyUserTrackingPreferences() {
+        if(!mDataProvider.getUserHasOptedOut()) {
+            enableUserTracking();
+        }
+        else{
+            disableUserTracking();
+        }
+    }
+
+    private static void enableUserTracking() {
+        TracksUser tracksUser = mDataProvider.currentUser();
+
+        sentry.getContext().setUser(new UserBuilder()
+                .setEmail(tracksUser.getEmail())
+                .setUsername(tracksUser.getUsername())
+                .withData("userID", tracksUser.getUserID())
+                .build()
+        );
+    }
+
+    private static void disableUserTracking() {
+        sentry.clearContext();
+    }
+
+    public static void setContext(Map<String, Object> context) {
+        sentry.setExtra(context);
+    }
+
+    // Locale Helpers
+    private static String getCurrentLanguage(@Nullable Locale locale) {
+        if (locale == null) {
+            return "unknown";
+        }
+
+        return locale.getLanguage();
+    }
+
+    // Logging Helpers
+    public static void log(Throwable e) {
+        sentry.sendException(e);
+    }
+
+    public static void log(@NotNull Throwable e, Map<String, String> data) {
+
+        Event event = new EventBuilder().withMessage(e.getMessage())
+                .withLevel(Event.Level.ERROR)
+                .withSentryInterface(new ExceptionInterface(e))
+                .getEvent();
+
+        sentry.sendEvent(event);
+    }
+
+    public static void log(String message) {
+        sentry.sendMessage(message);
+    }
+}

--- a/AutomatticTracks/src/main/java/com/automattic/android/tracks/CrashLogging/CrashLogging.java
+++ b/AutomatticTracks/src/main/java/com/automattic/android/tracks/CrashLogging/CrashLogging.java
@@ -27,7 +27,17 @@ public class CrashLogging {
     private static CrashLoggingDataProvider mDataProvider;
     private static SentryClient sentry;
 
+    private static Boolean isStarted = false;
+
     public static void start(Context context, CrashLoggingDataProvider dataProvider) {
+
+        synchronized (isStarted) {
+            if (isStarted) {
+                return;
+            }
+
+            isStarted = true;
+        }
 
         sentry = Sentry.init(
                 dataProvider.sentryDSN(),

--- a/AutomatticTracks/src/main/java/com/automattic/android/tracks/CrashLogging/CrashLogging.java
+++ b/AutomatticTracks/src/main/java/com/automattic/android/tracks/CrashLogging/CrashLogging.java
@@ -122,15 +122,17 @@ public class CrashLogging {
         sentry.sendException(e);
     }
 
-    public static void log(@NotNull Throwable e, Map<String, String> data) {
+    public static void log(@NotNull Throwable e, @Nullable Map<String, String> data) {
 
         EventBuilder eventBuilder = new EventBuilder()
                 .withMessage(e.getMessage())
                 .withLevel(Event.Level.ERROR)
                 .withSentryInterface(new ExceptionInterface(e));
 
-        for (Map.Entry<String,String> entry : data.entrySet()) {
-            eventBuilder.withExtra(entry.getKey(), entry.getValue());
+        if (data != null) {
+            for (Map.Entry<String,String> entry : data.entrySet()) {
+                eventBuilder.withExtra(entry.getKey(), entry.getValue());
+            }
         }
 
         sentry.sendEvent(eventBuilder.getEvent());

--- a/AutomatticTracks/src/main/java/com/automattic/android/tracks/CrashLogging/CrashLogging.java
+++ b/AutomatticTracks/src/main/java/com/automattic/android/tracks/CrashLogging/CrashLogging.java
@@ -124,12 +124,16 @@ public class CrashLogging {
 
     public static void log(@NotNull Throwable e, Map<String, String> data) {
 
-        Event event = new EventBuilder().withMessage(e.getMessage())
+        EventBuilder eventBuilder = new EventBuilder()
+                .withMessage(e.getMessage())
                 .withLevel(Event.Level.ERROR)
-                .withSentryInterface(new ExceptionInterface(e))
-                .getEvent();
+                .withSentryInterface(new ExceptionInterface(e));
 
-        sentry.sendEvent(event);
+        for (Map.Entry<String,String> entry : data.entrySet()) {
+            eventBuilder.withExtra(entry.getKey(), entry.getValue());
+        }
+
+        sentry.sendEvent(eventBuilder.getEvent());
     }
 
     public static void log(String message) {

--- a/AutomatticTracks/src/main/java/com/automattic/android/tracks/CrashLogging/CrashLoggingDataProvider.java
+++ b/AutomatticTracks/src/main/java/com/automattic/android/tracks/CrashLogging/CrashLoggingDataProvider.java
@@ -1,0 +1,72 @@
+package com.automattic.android.tracks.CrashLogging;
+
+import com.automattic.android.tracks.TracksUser;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Locale;
+import java.util.Map;
+
+public interface CrashLoggingDataProvider {
+    /**
+     * Provides the Crash Logging Service with the Sentry DSN for this application.
+     * @return The Sentry DSN for this application.
+     */
+    String sentryDSN();
+
+    /**
+     * Provides the Crash Logging Service with information on whether the user has opted out
+     * of data collection.
+     *
+     * The implementation of this method should fetch this value from persistent storage, and should
+     * never call `CrashLogging.getUserHasOptedOut()`.
+     *
+     * @return A value indicating whether or not the user has opted out of data collection.
+     */
+    boolean getUserHasOptedOut();
+
+    /**
+     * Allows persisting whether or not the user has opted out of data collection.
+     *
+     * The implementation of this method should write this value to persistent storage, and should
+     * never call `CrashLogging.setUserHasOptedOut()`.
+     *
+     * @param userHasOptedOut A value indicating whether or not the user has opted out
+     *                        of data collection
+     */
+    void setUserHasOptedOut(boolean userHasOptedOut);
+
+    /**
+     * Provides the Crash Logging Service with information on what type of build this is.
+     * @return The build type
+     */
+    @NotNull String buildType();
+
+    /**
+     * Provides the Crash Logging Service with the name of this release.
+     * @return The release name
+     */
+    @NotNull String releaseName();
+
+    /**
+     * Provides the Crash Logging Service with information about the current user.
+     * @return A `TracksUser` object containing data about the current user.
+     *
+     * @see TracksUser
+     */
+    @Nullable TracksUser currentUser();
+
+    /**
+     * Provides the Crash Logging Service with information about the current system state.
+     *
+     * @see TracksUser
+     */
+    @NotNull  Map<String, Object> context();
+
+    /**
+     * Provides the Crash Logging Service with information about the user's current locale
+     *
+     */
+    @Nullable Locale locale();
+}

--- a/AutomatticTracks/src/main/java/com/automattic/android/tracks/CrashLogging/CrashLoggingDataProvider.java
+++ b/AutomatticTracks/src/main/java/com/automattic/android/tracks/CrashLogging/CrashLoggingDataProvider.java
@@ -10,13 +10,13 @@ import java.util.Map;
 
 public interface CrashLoggingDataProvider {
     /**
-     * Provides the Crash Logging Service with the Sentry DSN for this application.
+     * Provides {@link CrashLogging} with the Sentry DSN for this application.
      * @return The Sentry DSN for this application.
      */
     String sentryDSN();
 
     /**
-     * Provides the Crash Logging Service with information on whether the user has opted out
+     * Provides {@link CrashLogging} with information on whether the user has opted out
      * of data collection.
      *
      * The implementation of this method should fetch this value from persistent storage, and should
@@ -27,30 +27,19 @@ public interface CrashLoggingDataProvider {
     boolean getUserHasOptedOut();
 
     /**
-     * Allows persisting whether or not the user has opted out of data collection.
-     *
-     * The implementation of this method should write this value to persistent storage, and should
-     * never call `CrashLogging.setUserHasOptedOut()`.
-     *
-     * @param userHasOptedOut A value indicating whether or not the user has opted out
-     *                        of data collection
-     */
-    void setUserHasOptedOut(boolean userHasOptedOut);
-
-    /**
-     * Provides the Crash Logging Service with information on what type of build this is.
+     * Provides {@link CrashLogging} with information on what type of build this is.
      * @return The build type
      */
     @NotNull String buildType();
 
     /**
-     * Provides the Crash Logging Service with the name of this release.
+     * Provides {@link CrashLogging} with the name of this release.
      * @return The release name
      */
     @NotNull String releaseName();
 
     /**
-     * Provides the Crash Logging Service with information about the current user.
+     * Provides {@link CrashLogging} with information about the current user.
      * @return A `TracksUser` object containing data about the current user.
      *
      * @see TracksUser
@@ -58,14 +47,17 @@ public interface CrashLoggingDataProvider {
     @Nullable TracksUser currentUser();
 
     /**
-     * Provides the Crash Logging Service with information about the current system state.
-     *
-     * @see TracksUser
+     * Provides the {@link CrashLogging} with information about the current application state.
      */
-    @NotNull  Map<String, Object> context();
+    @NotNull Map<String, Object> applicationContext();
 
     /**
-     * Provides the Crash Logging Service with information about the user's current locale
+     * Provides the {@link CrashLogging} with information about the current application state.
+     */
+    @NotNull Map<String, Object> userContext();
+
+    /**
+     * Provides the {@link CrashLogging} with information about the user's current locale
      *
      */
     @Nullable Locale locale();

--- a/AutomatticTracks/src/main/java/com/automattic/android/tracks/TracksUser.java
+++ b/AutomatticTracks/src/main/java/com/automattic/android/tracks/TracksUser.java
@@ -1,0 +1,26 @@
+package com.automattic.android.tracks;
+
+public class TracksUser {
+
+    private String mUserID;
+    private String mEmail;
+    private String mUsername;
+
+    public TracksUser(String userID, String email, String username) {
+        mUserID = userID;
+        mEmail = email;
+        mUsername = username;
+    }
+
+    public String getUsername() {
+        return mUsername;
+    }
+
+    public String getEmail() {
+        return mEmail;
+    }
+
+    public String getUserID() {
+        return mUserID;
+    }
+}


### PR DESCRIPTION
This PR adds support for using Tracks as a wrapper around any crash logging service – in this case, Sentry.

If, in the future, apps needed to work with another crash logging provider, it'd be simple enough to swap out the implementation without disrupting any of the other applications.

Additionally, a lot of the low-level bookkeeping work is now represented here, ensuring that we don't have code duplication in many different applications. This will become more important as features such as log processing are added.

This PR is the counterpart to https://github.com/Automattic/Automattic-Tracks-iOS/pull/103

**Sample implementations:**
https://github.com/woocommerce/woocommerce-android/pull/1071
