### PR TITLE
Use android annotations

### DIFF
--- a/AutomatticTracks/build.gradle
+++ b/AutomatticTracks/build.gradle
@@ -20,7 +20,7 @@ repositories {
 
 dependencies {
     implementation 'io.sentry:sentry-android:1.7.16'
-    implementation 'org.jetbrains:annotations-java5:15.0'
+    implementation 'com.android.support:support-annotations:28.0.0'
 }
 
 android {

--- a/AutomatticTracks/src/main/java/com/automattic/android/tracks/CrashLogging/CrashLogging.java
+++ b/AutomatticTracks/src/main/java/com/automattic/android/tracks/CrashLogging/CrashLogging.java
@@ -1,13 +1,12 @@
 package com.automattic.android.tracks.CrashLogging;
 
 import android.content.Context;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.util.Log;
 
 import com.automattic.android.tracks.BuildConfig;
 import com.automattic.android.tracks.TracksUser;
-
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 import java.util.Locale;
 import java.util.Map;
@@ -122,7 +121,7 @@ public class CrashLogging {
         sentry.sendException(e);
     }
 
-    public static void log(@NotNull Throwable e, @Nullable Map<String, String> data) {
+    public static void log(@NonNull Throwable e, @Nullable Map<String, String> data) {
 
         EventBuilder eventBuilder = new EventBuilder()
                 .withMessage(e.getMessage())

--- a/AutomatticTracks/src/main/java/com/automattic/android/tracks/CrashLogging/CrashLogging.java
+++ b/AutomatticTracks/src/main/java/com/automattic/android/tracks/CrashLogging/CrashLogging.java
@@ -13,7 +13,6 @@ import java.util.Map;
 
 import io.sentry.Sentry;
 import io.sentry.SentryClient;
-import io.sentry.event.User;
 import io.sentry.android.AndroidSentryClientFactory;
 import io.sentry.connection.EventSendCallback;
 import io.sentry.event.Event;

--- a/AutomatticTracks/src/main/java/com/automattic/android/tracks/CrashLogging/CrashLoggingDataProvider.java
+++ b/AutomatticTracks/src/main/java/com/automattic/android/tracks/CrashLogging/CrashLoggingDataProvider.java
@@ -1,9 +1,9 @@
 package com.automattic.android.tracks.CrashLogging;
 
-import com.automattic.android.tracks.TracksUser;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import com.automattic.android.tracks.TracksUser;
 
 import java.util.Locale;
 import java.util.Map;
@@ -30,13 +30,13 @@ public interface CrashLoggingDataProvider {
      * Provides {@link CrashLogging} with information on what type of build this is.
      * @return The build type
      */
-    @NotNull String buildType();
+    @NonNull String buildType();
 
     /**
      * Provides {@link CrashLogging} with the name of this release.
      * @return The release name
      */
-    @NotNull String releaseName();
+    @NonNull String releaseName();
 
     /**
      * Provides {@link CrashLogging} with information about the current user.
@@ -49,12 +49,12 @@ public interface CrashLoggingDataProvider {
     /**
      * Provides the {@link CrashLogging} with information about the current application state.
      */
-    @NotNull Map<String, Object> applicationContext();
+    @NonNull Map<String, Object> applicationContext();
 
     /**
      * Provides the {@link CrashLogging} with information about the current application state.
      */
-    @NotNull Map<String, Object> userContext();
+    @NonNull Map<String, Object> userContext();
 
     /**
      * Provides the {@link CrashLogging} with information about the user's current locale


### PR DESCRIPTION
Replaces the Jetbrains annotation package (introduced in https://github.com/Automattic/Automattic-Tracks-Android/pull/46 for nullability annotations) with the standard Android support library one.

I was working on an update to this library and noticed a dependency resolution error when using the existing `1.2` version in WPAndroid. It looks like we were importing version `15.0` of `org.jetbrains:annotations-java5` here and `13.0` somewhere else in WPAndroid's dependency tree. That could be solved by excluding on import, but I suspect there's no specific reason to use that library and we can instead just use the standard Android support library version of those annotations that won't cause any conflicts (I assume it was due to an auto-import).

@jkmassel if there was a specific reason for using that annotation library instead please let me know though.

I'll be opening another PR with my actual change to the library, I'll take care of bumping the version and pushing a new release to Bintray with that PR.

BTW I was surprised why WPAndroid isn't already using the latest version, aren't the Sentry changes needed there?

### To test
1. Check out this branch locally
2. Bump the `versionName` in `AutomatticTracks/build.gradle` to something like `1.2.1-rc-1`
3. Run `./gradlew clean assemble publishToMavenLocal` and check that it succeeds
4. In WPAndroid, open the root `build.gradle` file and add `mavenLocal()` to the top of the `repositories` block inside the `allprojects` block:
```groovy
allprojects {
    apply plugin: 'checkstyle'

    repositories {
        mavenLocal()
        google()
...
```
5. Still in WPAndroid, open `libs/analytics/WordPressAnalytics/build.gradle`, and bump `com.automattic:tracks` to the version you defined in step 2
6. Check that WPAndroid builds