### PR TITLE
Fix width and height tracking

### DIFF
--- a/AutomatticTracks/build.gradle
+++ b/AutomatticTracks/build.gradle
@@ -27,7 +27,7 @@ android {
     compileSdkVersion 26
 
     defaultConfig {
-        versionName "1.2"
+        versionName "1.2.1-beta-1"
         minSdkVersion 14
         targetSdkVersion 25
     }

--- a/AutomatticTracks/build.gradle
+++ b/AutomatticTracks/build.gradle
@@ -27,7 +27,7 @@ android {
     compileSdkVersion 26
 
     defaultConfig {
-        versionName "1.2.1-beta-1"
+        versionName "1.2.1-beta-2"
         minSdkVersion 14
         targetSdkVersion 25
     }

--- a/AutomatticTracks/src/main/java/com/automattic/android/tracks/DeviceInformation.java
+++ b/AutomatticTracks/src/main/java/com/automattic/android/tracks/DeviceInformation.java
@@ -195,7 +195,9 @@ import java.util.Locale;
         }
         try {
             // Width and height depend on device orientation - to be consistent, always
-            // report the shorter dimension as the width
+            // report the shorter dimension as the width.
+            // These values represent the 'real' dimensions of the screen, ignoring navigation
+            // and window decoration.
             if (mHeightPixels > mWidthPixels) {
                 mImmutableDeviceInfoJSON.put("display_height", mHeightPixels);
                 mImmutableDeviceInfoJSON.put("display_width", mWidthPixels);
@@ -205,6 +207,21 @@ import java.util.Locale;
             }
         } catch (final JSONException e) {
             Log.e(LOGTAG, "Exception writing display_height and width value in JSON object", e);
+        }
+        try {
+            // Width and height depend on device orientation - to be consistent, always
+            // report the shorter dimension as the width.
+            // These values represent the usable dimensions of the screen - whatever is left after
+            // navigation and window decoration.
+            if (mDisplayMetrics.heightPixels > mDisplayMetrics.widthPixels) {
+                mImmutableDeviceInfoJSON.put("display_usable_height", mDisplayMetrics.heightPixels);
+                mImmutableDeviceInfoJSON.put("display_usable_width", mDisplayMetrics.widthPixels);
+            } else {
+                mImmutableDeviceInfoJSON.put("display_usable_height", mDisplayMetrics.widthPixels);
+                mImmutableDeviceInfoJSON.put("display_usable_width", mDisplayMetrics.heightPixels);
+            }
+        } catch (final JSONException e) {
+            Log.e(LOGTAG, "Exception writing display_usable_height and width value in JSON object", e);
         }
         try {
             mImmutableDeviceInfoJSON.put("bluetooth_version", getBluetoothVersion());

--- a/AutomatticTracks/src/main/java/com/automattic/android/tracks/DeviceInformation.java
+++ b/AutomatticTracks/src/main/java/com/automattic/android/tracks/DeviceInformation.java
@@ -182,8 +182,8 @@ import java.util.Locale;
             int densityDpi = getDisplayMetrics().densityDpi;
             mImmutableDeviceInfoJSON.put("display_density_dpi", densityDpi);
             if (densityDpi > 0) {
-                double height = getDeviceHeightPixels() / (double) densityDpi;
-                double width = getDeviceWidthPixels() / (double) densityDpi;
+                double height = mHeightPixels / (double) densityDpi;
+                double width = mWidthPixels / (double) densityDpi;
                 double size = Math.hypot(width, height);
                 // Format it now
                 size = Math.round(size * 10d) / 10d;
@@ -410,14 +410,6 @@ import java.util.Locale;
         } else {
             return false;
         }
-    }
-
-    public int getDeviceWidthPixels() {
-        return mWidthPixels;
-    }
-
-    public int getDeviceHeightPixels() {
-        return mHeightPixels;
     }
 
     public String getDeviceLanguage() {

--- a/AutomatticTracks/src/main/java/com/automattic/android/tracks/DeviceInformation.java
+++ b/AutomatticTracks/src/main/java/com/automattic/android/tracks/DeviceInformation.java
@@ -194,6 +194,19 @@ import java.util.Locale;
             Log.e(LOGTAG, "Exception writing display_density_dpi value in JSON object", e);
         }
         try {
+            // Width and height depend on device orientation - to be consistent, always
+            // report the shorter dimension as the width
+            if (mHeightPixels > mWidthPixels) {
+                mImmutableDeviceInfoJSON.put("display_height", mHeightPixels);
+                mImmutableDeviceInfoJSON.put("display_width", mWidthPixels);
+            } else {
+                mImmutableDeviceInfoJSON.put("display_height", mWidthPixels);
+                mImmutableDeviceInfoJSON.put("display_width", mHeightPixels);
+            }
+        } catch (final JSONException e) {
+            Log.e(LOGTAG, "Exception writing display_height and width value in JSON object", e);
+        }
+        try {
             mImmutableDeviceInfoJSON.put("bluetooth_version", getBluetoothVersion());
         } catch (final JSONException e) {
             Log.e(LOGTAG, "Exception writing bluetooth info values in JSON object", e);

--- a/AutomatticTracks/src/main/java/com/automattic/android/tracks/MessageBuilder.java
+++ b/AutomatticTracks/src/main/java/com/automattic/android/tracks/MessageBuilder.java
@@ -24,8 +24,6 @@ class MessageBuilder {
     private static final String USER_ID_KEY = "_ui";
     private static final String USER_LANG_KEY = "_lg";
     private static final String USER_LOGIN_NAME_KEY = "_ul";
-    private static final String DEVICE_HEIGHT_PIXELS_KEY = "_ht";
-    private static final String DEVICE_WIDTH_PIXELS_KEY = "_wd";
 
     public static final String ALIAS_USER_EVENT_NAME = "_aliasUser";
     public static final String ALIAS_USER_ANONID_PROP_NAME = "anonId";
@@ -38,8 +36,6 @@ class MessageBuilder {
                 keyToTestLowercase.equals(REQUEST_TIMESTAMP_KEY) ||
                 keyToTestLowercase.equals(USER_TYPE_KEY) ||
                 keyToTestLowercase.equals(USER_ID_KEY) ||
-                keyToTestLowercase.equals(DEVICE_WIDTH_PIXELS_KEY) ||
-                keyToTestLowercase.equals(DEVICE_HEIGHT_PIXELS_KEY) ||
                 keyToTestLowercase.equals(USER_LANG_KEY) ||
                 keyToTestLowercase.equals(USER_LOGIN_NAME_KEY)
                 ) {
@@ -63,13 +59,6 @@ class MessageBuilder {
             commonProps.put(USER_AGENT_NAME_KEY, userAgent);
         } catch (JSONException e) {
             Log.e(TracksClient.LOGTAG, "Cannot add the "+  USER_AGENT_NAME_KEY + " property to request commons.");
-        }
-
-        try {
-            commonProps.put(DEVICE_WIDTH_PIXELS_KEY, deviceInformation.getDeviceWidthPixels());
-            commonProps.put(DEVICE_HEIGHT_PIXELS_KEY, deviceInformation.getDeviceHeightPixels());
-        } catch (JSONException e) {
-            Log.e(TracksClient.LOGTAG, "Cannot add the device width/height properties to request commons.");
         }
 
         try {


### PR DESCRIPTION
**~Note: While testing this PR I noticed that we seem to already be sending the data I needed as `_wd` and `_ht` properties, but those don't seem exposed in the Tracks frontend. I wonder if they're being filtered out automatically on the backend for some reason - I'm looking into this, this PR is on hold for now.~** (p4qSXL-3xm-p2)

_Once merged I'll push a new release to bintray and open a WPAndroid PR updating the version._

Adds two more properties to the default data we send with each tracks event: `device_info_display_height` and `device_info_display_width`.

**Update:** These are replacing the existing `_ht` and `_wd` params we'd already been sending. It turns out these were deprecated a few months ago and are ignored in the backend. (p4qSXL-3xm-p2)

This was prompted by ongoing work on the WP Stories feature. We're looking at standardizing exported slide sizes to a 9:16 ratio, and are assuming a relative rarity of WPAndroid devices with a wider than 9:16 ratio. Having some data on width/height will let us check our assumptions here.

Note that the width/height reported is [the _real_ width/height](https://github.com/Automattic/Automattic-Tracks-Android/blob/8c6b9b7dc3c8b63c10766ec7e2d9b61d09766cf7/AutomatticTracks/src/main/java/com/automattic/android/tracks/DeviceInformation.java#L146-L150), which is to say the real size of the display without subtracting any window decor. This is how we're also already calculating display size as hypotenuse, and should be appropriate given the stories view is a fullscreen experience, and this is inline with how other metrics websites report device screen size from what I can tell.

### To test
1. Check out this branch locally
2. Run `./gradlew clean assemble publishToMavenLocal` and check that it succeeds
3. In WPAndroid, open the root `build.gradle` file and add `mavenLocal()` to the top of the `repositories` block inside the `allprojects` block:
```groovy
allprojects {
    apply plugin: 'checkstyle'

    repositories {
        mavenLocal()
        google()
...
```
4. Still in WPAndroid, open `libs/analytics/WordPressAnalytics/build.gradle`, and bump `com.automattic:tracks` to `1.2.1-beta-1`
6. Check that WPAndroid builds
7. Hook up a network listener like Charles, run WPAndroid, and wait for a tracks event to be broadcast (https://public-api.wordpress.com/rest/v1.1/tracks/record) - backgrounding and foregrounding the app should trigger a call
8. Examine the data sent, you should see a `commonProps` object which should include height/width information:
```js
"commonProps": {
  ...
  "device_info_display_height": "2160",
  "device_info_display_width": "1080",
  ...
```
9. Also confirm that the `_ht` and `_wd` props are no longer included