### PR TITLE
Enable `androidx`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,9 @@ jobs:
       - checkout
       - android/restore-gradle-cache
       - run:
+          name: Setup gradle.properties
+          command: cp gradle.properties-example gradle.properties
+      - run:
           name: Assemble .aar
           command: ./gradlew --stacktrace assembleRelease
       - run:

--- a/.gitignore
+++ b/.gitignore
@@ -38,7 +38,7 @@ proguard/
 .idea/
 
 # private config file
-AutomatticTracks/gradle.properties
+gradle.properties
 
 # OS X generated file
 .DS_Store

--- a/AutomatticTracks/build.gradle
+++ b/AutomatticTracks/build.gradle
@@ -20,7 +20,7 @@ repositories {
 
 dependencies {
     implementation 'io.sentry:sentry-android:1.7.16'
-    implementation 'com.android.support:support-annotations:28.0.0'
+    implementation 'androidx.annotation:annotation:1.1.0'
 }
 
 android {

--- a/AutomatticTracks/gradle.properties-example
+++ b/AutomatticTracks/gradle.properties-example
@@ -1,6 +1,0 @@
-ossrhUsername=hello
-ossrhPassword=world
-
-signing.keyId=byebye
-signing.password=secret
-signing.secretKeyRingFile=/home/user/secret.gpg

--- a/AutomatticTracks/src/main/java/com/automattic/android/tracks/CrashLogging/CrashLogging.java
+++ b/AutomatticTracks/src/main/java/com/automattic/android/tracks/CrashLogging/CrashLogging.java
@@ -1,9 +1,10 @@
 package com.automattic.android.tracks.CrashLogging;
 
 import android.content.Context;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 import android.util.Log;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.automattic.android.tracks.BuildConfig;
 import com.automattic.android.tracks.TracksUser;

--- a/AutomatticTracks/src/main/java/com/automattic/android/tracks/CrashLogging/CrashLoggingDataProvider.java
+++ b/AutomatticTracks/src/main/java/com/automattic/android/tracks/CrashLogging/CrashLoggingDataProvider.java
@@ -1,7 +1,7 @@
 package com.automattic.android.tracks.CrashLogging;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.automattic.android.tracks.TracksUser;
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+android.useAndroidX = true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,0 @@
-android.useAndroidX = true

--- a/gradle.properties-example
+++ b/gradle.properties-example
@@ -1,0 +1,1 @@
+android.useAndroidX=true

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,2 @@
+before_install:
+  - cp gradle.properties-example gradle.properties


### PR DESCRIPTION
This PR enables support for `androidx` namespace.

Link to passed Jitpack build: https://jitpack.io/com/github/Automattic/Automattic-Tracks-Android/issue~61-enable-androidx-d320a80e16-1/build.log

Resolves #61 