### PR TITLE
Add `Dependabot` configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "gradle"
+    directory: "AutomatticTracks/"
+    schedule:
+      interval: "daily"
+    allow:
+      - dependency-name: "io.sentry:sentry-android"


### PR DESCRIPTION
Resolves #73 

### Test

Please check my fork: I've lowered `Sentry SDK` there and setup the same dependabot config file: https://github.com/wzieba/Automattic-Tracks-Android/pull/1