### PR TITLE
Map `null` values of `SentryException` to empty string

### DIFF
--- a/AutomatticTracks/src/main/java/com/automattic/android/tracks/crashlogging/internal/SentryCrashLogging.kt
+++ b/AutomatticTracks/src/main/java/com/automattic/android/tracks/crashlogging/internal/SentryCrashLogging.kt
@@ -52,9 +52,9 @@ internal class SentryCrashLogging constructor(
     private fun dropExceptionIfRequired(event: SentryEvent) {
         event.exceptions?.lastOrNull()?.let { lastException ->
             if (dataProvider.shouldDropWrappingException(
-                    lastException.module,
-                    lastException.type,
-                    lastException.value
+                    lastException.module.orEmpty(),
+                    lastException.type.orEmpty(),
+                    lastException.value.orEmpty(),
                 )
             ) {
                 event.exceptions.remove(lastException)

--- a/AutomatticTracks/src/test/java/com/automattic/android/tracks/crashlogging/SentryCrashLoggingTest.kt
+++ b/AutomatticTracks/src/test/java/com/automattic/android/tracks/crashlogging/SentryCrashLoggingTest.kt
@@ -21,6 +21,7 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyZeroInteractions
+import org.mockito.kotlin.whenever
 import java.util.Locale
 
 class SentryCrashLoggingTest {
@@ -249,6 +250,28 @@ class SentryCrashLoggingTest {
         capturedOptions.beforeSend?.execute(testEvent, null)
 
         verifyZeroInteractions(testEvent)
+    }
+
+    @Test
+    fun `should map empty values of last exception bundled with an event`() {
+        val mockedShouldDropException = mock<(String, String, String) -> Boolean>()
+        whenever(mockedShouldDropException.invoke(any(), any(), any())).thenReturn(true)
+        dataProvider.shouldDropException = mockedShouldDropException
+        initialize()
+
+        val event = SentryEvent().apply {
+            exceptions = mutableListOf(
+                SentryException().apply {
+                    module = null
+                    type = null
+                    value = null
+                }
+            )
+        }
+
+        capturedOptions.beforeSend?.execute(event, null)
+
+        verify(mockedShouldDropException, times(1)).invoke("", "", "")
     }
 
     private val capturedOptions: SentryOptions


### PR DESCRIPTION
Resolves: #85 

There is a second possibility to resolve this: change signature of `CrashLoggingDataProvider#shouldDropWrappingException` from `(String, String, String)` to `(String?, String?, String?)`. I have no opinion about which would be better. I think the proposed one is just fine.

This PR doesn't require any testing, unit test is a sufficient assertion.