### PR TITLE
Use `tags` instead of `extra` for application context

### DIFF
--- a/AutomatticTracks/src/androidTest/java/com/automattic/android/tracks/crashlogging/SendEventsToSentry.kt
+++ b/AutomatticTracks/src/androidTest/java/com/automattic/android/tracks/crashlogging/SendEventsToSentry.kt
@@ -62,13 +62,13 @@ class SendEventsToSentry {
 
     @Test
     fun logMessageWithAppendedApplicationContext() {
-        crashLogging.appendApplicationContext(mapOf("1 application" to "context"))
+        dataProvider.applicationContext = mapOf("1 application" to "context")
         crashLogging.log(OutOfMemoryError())
 
-        crashLogging.appendApplicationContext(mapOf("2 application" to "context"))
+        dataProvider.applicationContext = mapOf("2 application" to "context")
         crashLogging.log(OutOfMemoryError())
 
-        crashLogging.appendApplicationContext(mapOf("1 application" to "updated context"))
+        dataProvider.applicationContext = mapOf("1 application" to "updated context")
         crashLogging.log(OutOfMemoryError())
     }
 

--- a/AutomatticTracks/src/main/java/com/automattic/android/tracks/crashlogging/CrashLogging.kt
+++ b/AutomatticTracks/src/main/java/com/automattic/android/tracks/crashlogging/CrashLogging.kt
@@ -1,7 +1,6 @@
 package com.automattic.android.tracks.crashlogging
 
 interface CrashLogging {
-    fun appendApplicationContext(newApplicationContext: Map<String, String>)
     fun log(throwable: Throwable)
     fun log(throwable: Throwable, data: Map<String, String?>)
     fun log(message: String)

--- a/AutomatticTracks/src/main/java/com/automattic/android/tracks/crashlogging/CrashLoggingDataProvider.kt
+++ b/AutomatticTracks/src/main/java/com/automattic/android/tracks/crashlogging/CrashLoggingDataProvider.kt
@@ -65,6 +65,11 @@ interface CrashLoggingDataProvider {
         currentExtras: Map<ExtraKnownKey, String>,
         eventLevel: EventLevel
     ): Map<ExtraKnownKey, String>
+
+    /**
+     * Provides the {@link CrashLogging} with information about the current application state.
+     */
+    fun applicationContextProvider(): Map<String, String>
 }
 
 typealias ExtraKnownKey = String

--- a/AutomatticTracks/src/main/java/com/automattic/android/tracks/crashlogging/internal/SentryCrashLogging.kt
+++ b/AutomatticTracks/src/main/java/com/automattic/android/tracks/crashlogging/internal/SentryCrashLogging.kt
@@ -29,12 +29,20 @@ internal class SentryCrashLogging constructor(
 
                     dropExceptionIfRequired(event)
                     appendExtra(event)
-                    event.apply {
-                        user = dataProvider.userProvider()?.toSentryUser()
-                    }
+                    appendTags(event)
+                    appendUser(event)
+                    event
                 }
             }
         }
+    }
+
+    private fun appendUser(event: SentryEvent) {
+        event.user = dataProvider.userProvider()?.toSentryUser()
+    }
+
+    private fun appendTags(event: SentryEvent) {
+        event.setTags(dataProvider.applicationContextProvider())
     }
 
     private fun appendExtra(event: SentryEvent) {
@@ -59,12 +67,6 @@ internal class SentryCrashLogging constructor(
             ) {
                 event.exceptions.remove(lastException)
             }
-        }
-    }
-
-    override fun appendApplicationContext(newApplicationContext: Map<String, String>) {
-        newApplicationContext.forEach { entry ->
-            sentryWrapper.applyExtra(entry.key, entry.value)
         }
     }
 

--- a/AutomatticTracks/src/main/java/com/automattic/android/tracks/crashlogging/internal/SentryCrashLogging.kt
+++ b/AutomatticTracks/src/main/java/com/automattic/android/tracks/crashlogging/internal/SentryCrashLogging.kt
@@ -52,9 +52,9 @@ internal class SentryCrashLogging constructor(
     private fun dropExceptionIfRequired(event: SentryEvent) {
         event.exceptions?.lastOrNull()?.let { lastException ->
             if (dataProvider.shouldDropWrappingException(
-                    lastException.module,
-                    lastException.type,
-                    lastException.value
+                    lastException.module.orEmpty(),
+                    lastException.type.orEmpty(),
+                    lastException.value.orEmpty(),
                 )
             ) {
                 event.exceptions.remove(lastException)

--- a/AutomatticTracks/src/main/java/com/automattic/android/tracks/crashlogging/internal/SentryErrorTrackerWrapper.kt
+++ b/AutomatticTracks/src/main/java/com/automattic/android/tracks/crashlogging/internal/SentryErrorTrackerWrapper.kt
@@ -25,8 +25,4 @@ internal class SentryErrorTrackerWrapper {
     fun captureMessage(message: String) {
         Sentry.captureMessage(message)
     }
-
-    fun applyExtra(key: String, value: String) {
-        Sentry.setExtra(key, value)
-    }
 }

--- a/AutomatticTracks/src/sharedTest/kotlin/com/automattic/android/tracks/fakes/FakeDataProvider.kt
+++ b/AutomatticTracks/src/sharedTest/kotlin/com/automattic/android/tracks/fakes/FakeDataProvider.kt
@@ -17,7 +17,8 @@ class FakeDataProvider(
     var crashLoggingEnabled: Boolean = true,
     var shouldDropException: (String, String, String) -> Boolean = { _: String, _: String, _: String -> false },
     var extraKeys: List<String> = emptyList(),
-    var provideExtrasForEvent: (Map<ExtraKnownKey, String>) -> Map<ExtraKnownKey, String> = { emptyMap() }
+    var provideExtrasForEvent: (Map<ExtraKnownKey, String>) -> Map<ExtraKnownKey, String> = { emptyMap() },
+    var applicationContext: Map<String, String> = emptyMap(),
 ) : CrashLoggingDataProvider {
 
     override fun userProvider(): CrashLoggingUser? {
@@ -37,6 +38,10 @@ class FakeDataProvider(
         eventLevel: EventLevel
     ): Map<ExtraKnownKey, String> {
         return provideExtrasForEvent(currentExtras)
+    }
+
+    override fun applicationContextProvider(): Map<String, String> {
+        return applicationContext
     }
 
     override fun shouldDropWrappingException(module: String, type: String, value: String): Boolean {

--- a/AutomatticTracks/src/test/java/com/automattic/android/tracks/crashlogging/SentryCrashLoggingTest.kt
+++ b/AutomatticTracks/src/test/java/com/automattic/android/tracks/crashlogging/SentryCrashLoggingTest.kt
@@ -21,6 +21,7 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyZeroInteractions
+import org.mockito.kotlin.whenever
 import java.util.Locale
 
 class SentryCrashLoggingTest {
@@ -249,6 +250,28 @@ class SentryCrashLoggingTest {
         capturedOptions.beforeSend?.execute(testEvent, null)
 
         verifyZeroInteractions(testEvent)
+    }
+
+    @Test
+    fun `should map empty values of last exception bundled with an event`() {
+        val mockedShouldDropException = mock<(String, String, String) -> Boolean>()
+        whenever(mockedShouldDropException.invoke(any(), any(), any())).thenReturn(true)
+        dataProvider.shouldDropException = mockedShouldDropException
+        initialize()
+
+        val event = SentryEvent().apply {
+            exceptions = mutableListOf(
+                SentryException().apply {
+                    module = null
+                    type = null
+                    value = null
+                }
+            )
+        }
+
+        capturedOptions.beforeSend?.execute(event, null)
+
+        verify(mockedShouldDropException, times(1)).invoke("", "", "")
     }
 
     private val capturedOptions: SentryOptions

--- a/sampletracksapp/src/main/java/com/example/sampletracksapp/MainActivity.kt
+++ b/sampletracksapp/src/main/java/com/example/sampletracksapp/MainActivity.kt
@@ -50,7 +50,11 @@ class MainActivity : AppCompatActivity() {
                     currentExtras: Map<ExtraKnownKey, String>,
                     eventLevel: EventLevel
                 ): Map<ExtraKnownKey, String> {
-                    return mapOf("extra" to "value")
+                    return mapOf("extra" to "event value")
+                }
+
+                override fun applicationContextProvider(): Map<String, String> {
+                    return mapOf("extra" to "application context")
                 }
             }
         )


### PR DESCRIPTION
Closes: #87 

Reasons for this change are described in the issue.

### How to test
1. Make sure there's `sentryTestProjectDSN` of the test project in `gradle.properties`
2. Run `logMessageWithAppendedApplicationContext`
3. Make sure there are 3 events reported:
- one with `1-application: context` tag
- one with `2-application: context` tag
- one with `1-application: updated context` tag

### Expected test result

<img width="866" alt="image" src="https://user-images.githubusercontent.com/5845095/114540102-70968d00-9c55-11eb-80aa-092db1b58c41.png">
