### PR TITLE
Support `breadcrumbs`, update interface methods

### DIFF
--- a/.run/recordEvent().run.xml
+++ b/.run/recordEvent().run.xml
@@ -1,8 +1,8 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="logMessageWithUpda...()" type="AndroidTestRunConfigurationType" factoryName="Android Instrumented Tests" nameIsGenerated="true">
+  <configuration default="false" name="recordEvent()" type="AndroidTestRunConfigurationType" factoryName="Android Instrumented Tests" nameIsGenerated="true">
     <module name="Automattic-Tracks-Android.AutomatticTracks" />
     <option name="TESTING_TYPE" value="3" />
-    <option name="METHOD_NAME" value="logMessageWithUpdatedUser" />
+    <option name="METHOD_NAME" value="recordEvent" />
     <option name="CLASS_NAME" value="com.automattic.android.tracks.crashlogging.SendEventsToSentry" />
     <option name="PACKAGE_NAME" value="" />
     <option name="INSTRUMENTATION_RUNNER_CLASS" value="" />

--- a/.run/recordException().run.xml
+++ b/.run/recordException().run.xml
@@ -1,0 +1,53 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="recordException()" type="AndroidTestRunConfigurationType" factoryName="Android Instrumented Tests" nameIsGenerated="true">
+    <module name="Automattic-Tracks-Android.AutomatticTracks" />
+    <option name="TESTING_TYPE" value="3" />
+    <option name="METHOD_NAME" value="recordException" />
+    <option name="CLASS_NAME" value="com.automattic.android.tracks.crashlogging.SendEventsToSentry" />
+    <option name="PACKAGE_NAME" value="" />
+    <option name="INSTRUMENTATION_RUNNER_CLASS" value="" />
+    <option name="EXTRA_OPTIONS" value="" />
+    <option name="INCLUDE_GRADLE_EXTRA_OPTIONS" value="false" />
+    <option name="CLEAR_LOGCAT" value="false" />
+    <option name="SHOW_LOGCAT_AUTOMATICALLY" value="false" />
+    <option name="SKIP_NOOP_APK_INSTALLATIONS" value="true" />
+    <option name="FORCE_STOP_RUNNING_APP" value="true" />
+    <option name="TARGET_SELECTION_MODE" value="DEVICE_AND_SNAPSHOT_COMBO_BOX" />
+    <option name="SELECTED_CLOUD_MATRIX_CONFIGURATION_ID" value="-1" />
+    <option name="SELECTED_CLOUD_MATRIX_PROJECT_ID" value="" />
+    <option name="DEBUGGER_TYPE" value="Auto" />
+    <Auto>
+      <option name="USE_JAVA_AWARE_DEBUGGER" value="false" />
+      <option name="SHOW_STATIC_VARS" value="true" />
+      <option name="WORKING_DIR" value="" />
+      <option name="TARGET_LOGGING_CHANNELS" value="lldb process:gdb-remote packets" />
+      <option name="SHOW_OPTIMIZED_WARNING" value="true" />
+    </Auto>
+    <Hybrid>
+      <option name="USE_JAVA_AWARE_DEBUGGER" value="false" />
+      <option name="SHOW_STATIC_VARS" value="true" />
+      <option name="WORKING_DIR" value="" />
+      <option name="TARGET_LOGGING_CHANNELS" value="lldb process:gdb-remote packets" />
+      <option name="SHOW_OPTIMIZED_WARNING" value="true" />
+    </Hybrid>
+    <Java />
+    <Native>
+      <option name="USE_JAVA_AWARE_DEBUGGER" value="false" />
+      <option name="SHOW_STATIC_VARS" value="true" />
+      <option name="WORKING_DIR" value="" />
+      <option name="TARGET_LOGGING_CHANNELS" value="lldb process:gdb-remote packets" />
+      <option name="SHOW_OPTIMIZED_WARNING" value="true" />
+    </Native>
+    <Profilers>
+      <option name="ADVANCED_PROFILING_ENABLED" value="false" />
+      <option name="STARTUP_PROFILING_ENABLED" value="false" />
+      <option name="STARTUP_CPU_PROFILING_ENABLED" value="false" />
+      <option name="STARTUP_CPU_PROFILING_CONFIGURATION_NAME" value="Sample Java Methods" />
+      <option name="STARTUP_NATIVE_MEMORY_PROFILING_ENABLED" value="false" />
+      <option name="NATIVE_MEMORY_SAMPLE_RATE_BYTES" value="2048" />
+    </Profilers>
+    <method v="2">
+      <option name="Android.Gradle.BeforeRunTask" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/.run/sendExceptionRepor...().run.xml
+++ b/.run/sendExceptionRepor...().run.xml
@@ -1,8 +1,8 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="shouldAppendExtraF...()" type="AndroidTestRunConfigurationType" factoryName="Android Instrumented Tests" nameIsGenerated="true">
+  <configuration default="false" name="sendExceptionRepor...()" type="AndroidTestRunConfigurationType" factoryName="Android Instrumented Tests" nameIsGenerated="true">
     <module name="Automattic-Tracks-Android.AutomatticTracks" />
     <option name="TESTING_TYPE" value="3" />
-    <option name="METHOD_NAME" value="shouldAppendExtraForKeyIfRequested" />
+    <option name="METHOD_NAME" value="sendExceptionReportWithTags" />
     <option name="CLASS_NAME" value="com.automattic.android.tracks.crashlogging.SendEventsToSentry" />
     <option name="PACKAGE_NAME" value="" />
     <option name="INSTRUMENTATION_RUNNER_CLASS" value="" />

--- a/.run/sendReportWithExtr...().run.xml
+++ b/.run/sendReportWithExtr...().run.xml
@@ -1,8 +1,8 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="logWithData()" type="AndroidTestRunConfigurationType" factoryName="Android Instrumented Tests" nameIsGenerated="true">
+  <configuration default="false" name="sendReportWithExtr...()" type="AndroidTestRunConfigurationType" factoryName="Android Instrumented Tests" nameIsGenerated="true">
     <module name="Automattic-Tracks-Android.AutomatticTracks" />
     <option name="TESTING_TYPE" value="3" />
-    <option name="METHOD_NAME" value="logWithData" />
+    <option name="METHOD_NAME" value="sendReportWithExtraDataApplied" />
     <option name="CLASS_NAME" value="com.automattic.android.tracks.crashlogging.SendEventsToSentry" />
     <option name="PACKAGE_NAME" value="" />
     <option name="INSTRUMENTATION_RUNNER_CLASS" value="" />

--- a/.run/sendReportWithMess...().run.xml
+++ b/.run/sendReportWithMess...().run.xml
@@ -1,8 +1,8 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="logWithException()" type="AndroidTestRunConfigurationType" factoryName="Android Instrumented Tests" nameIsGenerated="true">
+  <configuration default="false" name="sendReportWithMess...()" type="AndroidTestRunConfigurationType" factoryName="Android Instrumented Tests" nameIsGenerated="true">
     <module name="Automattic-Tracks-Android.AutomatticTracks" />
     <option name="TESTING_TYPE" value="3" />
-    <option name="METHOD_NAME" value="logWithException" />
+    <option name="METHOD_NAME" value="sendReportWithMessage" />
     <option name="CLASS_NAME" value="com.automattic.android.tracks.crashlogging.SendEventsToSentry" />
     <option name="PACKAGE_NAME" value="" />
     <option name="INSTRUMENTATION_RUNNER_CLASS" value="" />

--- a/.run/sendThreeReportsAn...().run.xml
+++ b/.run/sendThreeReportsAn...().run.xml
@@ -1,8 +1,8 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="logMessage()" type="AndroidTestRunConfigurationType" factoryName="Android Instrumented Tests" nameIsGenerated="true">
+  <configuration default="false" name="sendThreeReportsAn...()" type="AndroidTestRunConfigurationType" factoryName="Android Instrumented Tests" nameIsGenerated="true">
     <module name="Automattic-Tracks-Android.AutomatticTracks" />
     <option name="TESTING_TYPE" value="3" />
-    <option name="METHOD_NAME" value="logMessage" />
+    <option name="METHOD_NAME" value="sendThreeReportsAndChangeApplicationContextBetween" />
     <option name="CLASS_NAME" value="com.automattic.android.tracks.crashlogging.SendEventsToSentry" />
     <option name="PACKAGE_NAME" value="" />
     <option name="INSTRUMENTATION_RUNNER_CLASS" value="" />

--- a/.run/sendTwoReportsAndC...().run.xml
+++ b/.run/sendTwoReportsAndC...().run.xml
@@ -1,8 +1,8 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="logMessageWithAppe...()" type="AndroidTestRunConfigurationType" factoryName="Android Instrumented Tests" nameIsGenerated="true">
+  <configuration default="false" name="sendTwoReportsAndC...()" type="AndroidTestRunConfigurationType" factoryName="Android Instrumented Tests" nameIsGenerated="true">
     <module name="Automattic-Tracks-Android.AutomatticTracks" />
     <option name="TESTING_TYPE" value="3" />
-    <option name="METHOD_NAME" value="logMessageWithAppendedApplicationContext" />
+    <option name="METHOD_NAME" value="sendTwoReportsAndChangeUserBetween" />
     <option name="CLASS_NAME" value="com.automattic.android.tracks.crashlogging.SendEventsToSentry" />
     <option name="PACKAGE_NAME" value="" />
     <option name="INSTRUMENTATION_RUNNER_CLASS" value="" />

--- a/AutomatticTracks/src/androidTest/java/com/automattic/android/tracks/crashlogging/SendEventsToSentry.kt
+++ b/AutomatticTracks/src/androidTest/java/com/automattic/android/tracks/crashlogging/SendEventsToSentry.kt
@@ -46,10 +46,11 @@ class SendEventsToSentry {
 
     @Test
     fun sendExceptionReportWithTags() {
+        dataProvider.applicationContext = mapOf("application" to "context")
         crashLogging.sendReport(
             exception = IllegalThreadStateException(),
             tags = mapOf("test key" to "test value"),
-            message = "This should report IllegalThreadStateException and add `test key: test value` to tags"
+            message = "This should report IllegalThreadStateException and add `test key: test value` and `application: context` to tags"
         )
     }
 
@@ -124,7 +125,7 @@ class SendEventsToSentry {
 
         crashLogging.sendReport(
             exception = NegativeArraySizeException(),
-            message = "This should show `SentryTestException` in event's breadcrumbs"
+            message = "This should show `NotImplementedError` in event's breadcrumbs"
         )
     }
 

--- a/AutomatticTracks/src/androidTest/java/com/automattic/android/tracks/crashlogging/SendEventsToSentry.kt
+++ b/AutomatticTracks/src/androidTest/java/com/automattic/android/tracks/crashlogging/SendEventsToSentry.kt
@@ -99,7 +99,7 @@ class SendEventsToSentry {
         val extraKey = "key"
         dataProvider.extraKeys = listOf(extraKey)
         dataProvider.provideExtrasForEvent = { _ ->
-            mapOf("key" to "value")
+            mapOf(extraKey to "value")
         }
 
         crashLogging.sendReport(

--- a/AutomatticTracks/src/androidTest/java/com/automattic/android/tracks/crashlogging/SendEventsToSentry.kt
+++ b/AutomatticTracks/src/androidTest/java/com/automattic/android/tracks/crashlogging/SendEventsToSentry.kt
@@ -1,5 +1,6 @@
 package com.automattic.android.tracks.crashlogging
 
+import android.database.sqlite.SQLiteOutOfMemoryException
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.automattic.android.tracks.fakes.FakeDataProvider
@@ -9,6 +10,9 @@ import org.junit.AfterClass
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import java.io.NotActiveException
+import java.lang.NullPointerException
+import java.lang.invoke.WrongMethodTypeException
 
 /**
  * This class is *not* a test in a formal way. This is a helper tool for making it easier to send
@@ -21,6 +25,10 @@ import org.junit.runner.RunWith
  * Troubleshooting: if running this "test" results with `Test framework quit unexpectedly` make
  * sure, that `Include Extra Params from Gradle build file` under `Instrumentation arguments`
  * in run configuration is unchecked.
+ *
+ * <b> Why every event has different exception? </b>
+ * Sentry dashboard merges similar events. For making navigating there easier, we apply different
+ * exceptions to prevent merging.
  */
 @RunWith(AndroidJUnit4::class)
 class SendEventsToSentry {
@@ -37,50 +45,87 @@ class SendEventsToSentry {
     }
 
     @Test
-    fun logWithData() {
-        crashLogging.log(LogWithDataException, data = mapOf("test key" to "test value"))
+    fun sendExceptionReportWithTags() {
+        crashLogging.sendReport(
+            exception = IllegalThreadStateException(),
+            tags = mapOf("test key" to "test value"),
+            message = "This should report IllegalThreadStateException and add `test key: test value` to tags"
+        )
     }
 
     @Test
-    fun logWithException() {
-        crashLogging.log(Log)
+    fun sendReportWithMessage() {
+        crashLogging.sendReport(message = "This should send event with just a message")
     }
 
     @Test
-    fun logMessage() {
-        crashLogging.log("This is test message")
-    }
-
-    @Test
-    fun logMessageWithUpdatedUser() {
+    fun sendTwoReportsAndChangeUserBetween() {
         dataProvider.user = testUser1
-        crashLogging.log(NullPointerException())
+        crashLogging.sendReport(
+            exception = OutOfMemoryError(),
+            message = "This should apply ${testUser1.userID} user"
+        )
 
         dataProvider.user = testUser2
-        crashLogging.log(NullPointerException())
+        crashLogging.sendReport(
+            exception = NullPointerException(),
+            message = "This should apply ${testUser2.userID} user"
+        )
     }
 
     @Test
-    fun logMessageWithAppendedApplicationContext() {
+    fun sendThreeReportsAndChangeApplicationContextBetween() {
         dataProvider.applicationContext = mapOf("1 application" to "context")
-        crashLogging.log(OutOfMemoryError())
+        crashLogging.sendReport(
+            exception = NotActiveException(),
+            message = "This should show `1 application: context` tag"
+        )
 
         dataProvider.applicationContext = mapOf("2 application" to "context")
-        crashLogging.log(OutOfMemoryError())
+        crashLogging.sendReport(
+            exception = ExceptionInInitializerError(),
+            message = "This should show `2 application: context` tag"
+        )
 
         dataProvider.applicationContext = mapOf("1 application" to "updated context")
-        crashLogging.log(OutOfMemoryError())
+        crashLogging.sendReport(
+            exception = WrongMethodTypeException(),
+            message = "This should show `1 application: updated context` tag"
+        )
     }
 
     @Test
-    fun shouldAppendExtraForKeyIfRequested() {
+    fun sendReportWithExtraDataApplied() {
         val extraKey = "key"
         dataProvider.extraKeys = listOf(extraKey)
         dataProvider.provideExtrasForEvent = { _ ->
             mapOf("key" to "value")
         }
 
-        crashLogging.log("This is test message")
+        crashLogging.sendReport(
+            exception = ArrayIndexOutOfBoundsException(),
+            message = "This should contain `key: value` in event's extra data"
+        )
+    }
+
+    @Test
+    fun recordEvent() {
+        crashLogging.recordEvent("custom event", "custom category")
+
+        crashLogging.sendReport(
+            exception = SQLiteOutOfMemoryException(),
+            message = "This should show `custom event` with `custom category` in event's breadcrumbs"
+        )
+    }
+
+    @Test
+    fun recordException() {
+        crashLogging.recordException(NotImplementedError())
+
+        crashLogging.sendReport(
+            exception = NegativeArraySizeException(),
+            message = "This should show `SentryTestException` in event's breadcrumbs"
+        )
     }
 
     companion object {
@@ -94,7 +139,4 @@ class SendEventsToSentry {
             Thread.sleep(5000)
         }
     }
-
-    object LogWithDataException : Exception()
-    object Log : Exception()
 }

--- a/AutomatticTracks/src/main/java/com/automattic/android/tracks/crashlogging/CrashLogging.kt
+++ b/AutomatticTracks/src/main/java/com/automattic/android/tracks/crashlogging/CrashLogging.kt
@@ -1,7 +1,43 @@
 package com.automattic.android.tracks.crashlogging
 
 interface CrashLogging {
-    fun log(throwable: Throwable)
-    fun log(throwable: Throwable, data: Map<String, String?>)
-    fun log(message: String)
+
+    /**
+     * Records a breadcrumb during the app lifecycle but doesn't report an event. This basically
+     * adds more context for the next reports created and sent by [sendReport] or an unhandled
+     * exception report.
+     *
+     * @param[message] The message to attach to a breadcrumb
+     * @param[category] An optional category
+     */
+    fun recordEvent(
+        message: String,
+        category: String? = null
+    )
+
+    /**
+     * Records a breadcrumb with exception during the app lifecycle but doesn't report an event.
+     * This basically adds more context for the next reports created and sent by [sendReport] or an
+     * unhandled exception report.
+     *
+     * @param[exception] The message to attach to a breadcrumb
+     * @param[category] An optional category
+     */
+    fun recordException(
+        exception: Throwable,
+        category: String? = null
+    )
+
+    /**
+     * Sends a new event to crash logging service
+     *
+     * @param[exception] An optional exception to report
+     * @param[tags] Tags attached to event
+     * @param[message] An optional message attached to event
+     */
+    fun sendReport(
+        exception: Throwable? = null,
+        tags: Map<String, String> = emptyMap(),
+        message: String? = null
+    )
 }

--- a/AutomatticTracks/src/main/java/com/automattic/android/tracks/crashlogging/internal/SentryCrashLogging.kt
+++ b/AutomatticTracks/src/main/java/com/automattic/android/tracks/crashlogging/internal/SentryCrashLogging.kt
@@ -30,7 +30,7 @@ internal class SentryCrashLogging constructor(
 
                     dropExceptionIfRequired(event)
                     appendExtra(event)
-                    appendTags(event)
+                    appendApplicationContext(event)
                     appendUser(event)
                     event
                 }
@@ -42,8 +42,8 @@ internal class SentryCrashLogging constructor(
         event.user = dataProvider.userProvider()?.toSentryUser()
     }
 
-    private fun appendTags(event: SentryEvent) {
-        event.setTags(dataProvider.applicationContextProvider())
+    private fun appendApplicationContext(event: SentryEvent) {
+        event.appendTags(dataProvider.applicationContextProvider())
     }
 
     private fun appendExtra(event: SentryEvent) {
@@ -95,7 +95,7 @@ internal class SentryCrashLogging constructor(
         val event = SentryEvent(exception).apply {
             this.message = Message().apply { this.message = message }
             this.level = if (exception != null) SentryLevel.ERROR else SentryLevel.INFO
-            setTags(tags)
+            this.appendTags(tags)
         }
         sentryWrapper.captureEvent(event)
     }

--- a/AutomatticTracks/src/main/java/com/automattic/android/tracks/crashlogging/internal/SentryErrorTrackerWrapper.kt
+++ b/AutomatticTracks/src/main/java/com/automattic/android/tracks/crashlogging/internal/SentryErrorTrackerWrapper.kt
@@ -1,6 +1,7 @@
 package com.automattic.android.tracks.crashlogging.internal
 
 import android.content.Context
+import io.sentry.Breadcrumb
 import io.sentry.Sentry
 import io.sentry.SentryEvent
 import io.sentry.SentryOptions
@@ -14,15 +15,11 @@ internal class SentryErrorTrackerWrapper {
         }
     }
 
-    fun captureException(exception: Throwable) {
-        Sentry.captureException(exception)
-    }
-
     fun captureEvent(event: SentryEvent) {
         Sentry.captureEvent(event)
     }
 
-    fun captureMessage(message: String) {
-        Sentry.captureMessage(message)
+    fun addBreadcrumb(breadcrumb: Breadcrumb) {
+        Sentry.addBreadcrumb(breadcrumb)
     }
 }

--- a/AutomatticTracks/src/main/java/com/automattic/android/tracks/crashlogging/internal/SentryEventExt.kt
+++ b/AutomatticTracks/src/main/java/com/automattic/android/tracks/crashlogging/internal/SentryEventExt.kt
@@ -1,0 +1,9 @@
+package com.automattic.android.tracks.crashlogging.internal
+
+import io.sentry.SentryEvent
+
+internal fun SentryEvent.appendTags(tags: Map<String, String>) {
+    tags.forEach { (key, value) ->
+        this.setTag(key, value)
+    }
+}

--- a/AutomatticTracks/src/test/java/com/automattic/android/tracks/crashlogging/SentryCrashLoggingTest.kt
+++ b/AutomatticTracks/src/test/java/com/automattic/android/tracks/crashlogging/SentryCrashLoggingTest.kt
@@ -344,6 +344,23 @@ class SentryCrashLoggingTest {
         }
     }
 
+    @Test
+    fun `should apply both application context and single event tags`() {
+        initialize()
+        val applicationContext = mapOf("application" to "context")
+        val eventTags = mapOf("event" to "tags")
+        dataProvider.applicationContext = applicationContext
+
+        crashLogging.sendReport(tags = eventTags)
+        val updatedEvent = beforeSendModifiedEvent(capturedOptions, event = capturedEvent)
+
+        SoftAssertions().apply {
+            (applicationContext + eventTags).forEach { (key, value) ->
+                assertThat(updatedEvent?.getTag(key)).isEqualTo(value)
+            }
+        }.assertAll()
+    }
+
     private val capturedOptions: SentryOptions
         get() = argumentCaptor<(SentryOptions) -> Unit>().let { captor ->
             verify(mockedWrapper).initialize(any(), captor.capture())

--- a/AutomatticTracks/src/test/java/com/automattic/android/tracks/crashlogging/SentryCrashLoggingTest.kt
+++ b/AutomatticTracks/src/test/java/com/automattic/android/tracks/crashlogging/SentryCrashLoggingTest.kt
@@ -6,6 +6,7 @@ import com.automattic.android.tracks.crashlogging.internal.SentryErrorTrackerWra
 import com.automattic.android.tracks.fakes.FakeDataProvider
 import com.automattic.android.tracks.fakes.testUser1
 import com.automattic.android.tracks.fakes.testUser2
+import io.sentry.Breadcrumb
 import io.sentry.SentryEvent
 import io.sentry.SentryLevel
 import io.sentry.SentryOptions
@@ -165,27 +166,28 @@ class SentryCrashLoggingTest {
     }
 
     @Test
-    fun `should log exception`() {
+    fun `should sent a report with exception`() {
         initialize()
 
-        crashLogging.log(TEST_THROWABLE)
+        crashLogging.sendReport(TEST_THROWABLE)
 
-        verify(mockedWrapper, times(1)).captureException(TEST_THROWABLE)
+        assertThat(capturedEvent.throwable).isEqualTo(TEST_THROWABLE)
     }
 
     @Test
-    fun `should log exception with additional data`() {
-        val additionalData = mapOf<String, String?>("additional" to "data", "another" to "extra")
+    fun `should send a report with exception, tags and message`() {
+        val additionalData = mapOf("additional" to "data", "another" to "extra")
+        val testMessage = "test message"
         initialize()
 
-        crashLogging.log(TEST_THROWABLE, additionalData)
+        crashLogging.sendReport(TEST_THROWABLE, tags = additionalData, message = testMessage)
 
         capturedEvent.let { event ->
             SoftAssertions().apply {
-                assertThat(event.message?.message).isEqualTo(TEST_THROWABLE.message)
+                assertThat(event.message?.message).isEqualTo(testMessage)
                 assertThat(event.level).isEqualTo(SentryLevel.ERROR)
                 additionalData.forEach { additionalDataEntry ->
-                    assertThat(event.getExtra(additionalDataEntry.key))
+                    assertThat(event.getTag(additionalDataEntry.key))
                         .isEqualTo(additionalDataEntry.value)
                 }
             }.assertAll()
@@ -193,13 +195,18 @@ class SentryCrashLoggingTest {
     }
 
     @Test
-    fun `should log message`() {
+    fun `should send a report with message`() {
         val testMessage = "test message"
         initialize()
 
-        crashLogging.log(testMessage)
+        crashLogging.sendReport(message = testMessage)
 
-        verify(mockedWrapper, times(1)).captureMessage(testMessage)
+        capturedEvent.let { event ->
+            SoftAssertions().apply {
+                assertThat(event.message?.message).isEqualTo(testMessage)
+                assertThat(event.level).isEqualTo(SentryLevel.INFO)
+            }.assertAll()
+        }
     }
 
     @Test
@@ -303,6 +310,40 @@ class SentryCrashLoggingTest {
         verify(mockedShouldDropException, times(1)).invoke("", "", "")
     }
 
+    @Test
+    fun `should record exception to breadcrumbs`() {
+        initialize()
+
+        crashLogging.recordException(TEST_THROWABLE)
+
+        capturedBreadcrumb.let { breadcrumb ->
+            SoftAssertions().apply {
+                assertThat(breadcrumb.message).isEqualTo(TEST_THROWABLE.toString())
+                assertThat(breadcrumb.type).isEqualTo("error")
+                assertThat(breadcrumb.category).isEqualTo(null)
+                assertThat(breadcrumb.level).isEqualTo(SentryLevel.ERROR)
+            }
+        }
+    }
+
+    @Test
+    fun `should record event with message and category to breadcrumbs`() {
+        val testMessage = "test message"
+        val testCategory = "test category"
+        initialize()
+
+        crashLogging.recordEvent(message = testMessage, category = testCategory)
+
+        capturedBreadcrumb.let { breadcrumb ->
+            SoftAssertions().apply {
+                assertThat(breadcrumb.message).isEqualTo(testMessage)
+                assertThat(breadcrumb.type).isEqualTo("default")
+                assertThat(breadcrumb.category).isEqualTo(testCategory)
+                assertThat(breadcrumb.level).isEqualTo(SentryLevel.INFO)
+            }
+        }
+    }
+
     private val capturedOptions: SentryOptions
         get() = argumentCaptor<(SentryOptions) -> Unit>().let { captor ->
             verify(mockedWrapper).initialize(any(), captor.capture())
@@ -315,6 +356,12 @@ class SentryCrashLoggingTest {
     private val capturedEvent: SentryEvent
         get() = argumentCaptor<SentryEvent>().let { captor ->
             verify(mockedWrapper).captureEvent(captor.capture())
+            captor.lastValue
+        }
+
+    private val capturedBreadcrumb
+        get() = argumentCaptor<Breadcrumb>().let { captor ->
+            verify(mockedWrapper).addBreadcrumb(captor.capture())
             captor.lastValue
         }
 

--- a/sampletracksapp/src/main/java/com/example/sampletracksapp/MainActivity.kt
+++ b/sampletracksapp/src/main/java/com/example/sampletracksapp/MainActivity.kt
@@ -63,15 +63,15 @@ class MainActivity : AppCompatActivity() {
             setContentView(root)
 
             logMessage.setOnClickListener {
-                crashLogging.log("Message from Tracks test app")
+                crashLogging.sendReport("Message from Tracks test app")
             }
 
             logException.setOnClickListener {
-                crashLogging.log(Exception("Exception from Tracks test app"))
+                crashLogging.sendReport(Exception("Exception from Tracks test app"))
             }
 
             logExceptionWithExtra.setOnClickListener {
-                crashLogging.log(
+                crashLogging.reportException(
                     throwable = Exception("Exception from Tracks test app with extra data"),
                     data = mapOf("extra" to "data bundled with exception")
                 )

--- a/sampletracksapp/src/main/java/com/example/sampletracksapp/MainActivity.kt
+++ b/sampletracksapp/src/main/java/com/example/sampletracksapp/MainActivity.kt
@@ -8,6 +8,7 @@ import com.automattic.android.tracks.crashlogging.CrashLoggingUser
 import com.automattic.android.tracks.crashlogging.EventLevel
 import com.automattic.android.tracks.crashlogging.ExtraKnownKey
 import com.example.sampletracksapp.databinding.ActivityMainBinding
+import java.lang.NullPointerException
 import java.util.Locale
 
 class MainActivity : AppCompatActivity() {
@@ -62,19 +63,20 @@ class MainActivity : AppCompatActivity() {
         ActivityMainBinding.inflate(layoutInflater).apply {
             setContentView(root)
 
-            logMessage.setOnClickListener {
-                crashLogging.sendReport("Message from Tracks test app")
+            sendReportWithMessage.setOnClickListener {
+                crashLogging.sendReport(message = "Message from Tracks test app")
             }
 
-            logException.setOnClickListener {
-                crashLogging.sendReport(Exception("Exception from Tracks test app"))
+            sendReportWithException.setOnClickListener {
+                crashLogging.sendReport(exception = Exception("Exception from Tracks test app"))
             }
 
-            logExceptionWithExtra.setOnClickListener {
-                crashLogging.reportException(
-                    throwable = Exception("Exception from Tracks test app with extra data"),
-                    data = mapOf("extra" to "data bundled with exception")
-                )
+            recordBreadcrumbWithMessage.setOnClickListener {
+                crashLogging.recordEvent(message = "Custom breadcrumb", category = "Custom category")
+            }
+
+            recordBreadcrumbWithException.setOnClickListener {
+                crashLogging.recordException(exception = NullPointerException(), category = "Custom exception category")
             }
         }
     }

--- a/sampletracksapp/src/main/res/layout/activity_main.xml
+++ b/sampletracksapp/src/main/res/layout/activity_main.xml
@@ -9,21 +9,33 @@
     tools:context=".MainActivity">
 
     <Button
-        android:id="@+id/logMessage"
+        android:id="@+id/sendReportWithMessage"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="Log message" />
+        android:text="Send report with message" />
 
     <Button
-        android:id="@+id/logException"
+        android:id="@+id/sendReportWithException"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="Log exception" />
+        android:text="Send report with exception" />
+
+    <View
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:layout_marginVertical="16dp"
+        android:background="@color/black" />
 
     <Button
-        android:id="@+id/logExceptionWithExtra"
+        android:id="@+id/recordBreadcrumbWithException"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="Log exception with extra data" />
+        android:text="Record breadcrumb with exception" />
+
+    <Button
+        android:id="@+id/recordBreadcrumbWithMessage"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Record breadcrumb with message" />
 
 </LinearLayout>


### PR DESCRIPTION
Resolves #75 

### Context

This PR adds support for `breadcrumbs` information and updates `CrashLogging` interface to make it similar to the one in `WPAndroid`. I think it's much easier to use this way.

I use word `breadcrumbs` in interfaces as it seems it's not a `Sentry`-related word. I don't know if it's common knowledge, I just mention it as TIL 😅 
<img width="669" alt="image" src="https://user-images.githubusercontent.com/5845095/114704557-064e1d00-9d27-11eb-8ad8-1e15efd89d33.png">


### How to test

This PR introduces a change of interface and a new feature so it's worth to check if every future works correctly. To make it easy to test now and in the future for any regression tests, I've prepared a strategy which makes testing really quick (**~ 5 minutes**). I'm open to any feedback to this idea - was it painless as I intended to make it?

1. Make sure there's `sentryTestProjectDSN` in `gradle.properties`
2. Go to `Sentry` dashboard of test project. Check all of the events, go to menu (3 dots) and delete all issues (to de-clutter the dashboard)
3. Run `SendEventsToSentry` (the whole class test)
4. Go back to `Sentry` dashboard.
5. Select any event. **Read a message that is applied to an event.** Make sure the event fulfills a requirement described in the message
6. Close the issue. Repeat step 5 until there's no events to check
