### PR TITLE
Fix a bug with `"null"` string instead of `null` value when applying extras to event

### DIFF
--- a/AutomatticTracks/src/main/java/com/automattic/android/tracks/crashlogging/internal/SentryCrashLogging.kt
+++ b/AutomatticTracks/src/main/java/com/automattic/android/tracks/crashlogging/internal/SentryCrashLogging.kt
@@ -3,6 +3,7 @@ package com.automattic.android.tracks.crashlogging.internal
 import android.content.Context
 import com.automattic.android.tracks.crashlogging.CrashLogging
 import com.automattic.android.tracks.crashlogging.CrashLoggingDataProvider
+import com.automattic.android.tracks.crashlogging.ExtraKnownKey
 import com.automattic.android.tracks.crashlogging.eventLevel
 import io.sentry.Breadcrumb
 import io.sentry.SentryEvent
@@ -55,8 +56,11 @@ internal class SentryCrashLogging constructor(
         )
     }
 
-    private fun mergeKnownKeysWithValues(event: SentryEvent) = dataProvider.extraKnownKeys()
-        .associateWith { knownKey -> event.getExtra(knownKey).toString() }
+    private fun mergeKnownKeysWithValues(event: SentryEvent): Map<ExtraKnownKey, String> =
+        dataProvider.extraKnownKeys()
+            .associateWith { knownKey -> event.getExtra(knownKey) }
+            .filterValues { it != null }
+            .mapValues(Any::toString)
 
     private fun dropExceptionIfRequired(event: SentryEvent) {
         event.exceptions?.lastOrNull()?.let { lastException ->

--- a/AutomatticTracks/src/sharedTest/kotlin/com/automattic/android/tracks/fakes/FakeDataProvider.kt
+++ b/AutomatticTracks/src/sharedTest/kotlin/com/automattic/android/tracks/fakes/FakeDataProvider.kt
@@ -17,7 +17,7 @@ class FakeDataProvider(
     var crashLoggingEnabled: Boolean = true,
     var shouldDropException: (String, String, String) -> Boolean = { _: String, _: String, _: String -> false },
     var extraKeys: List<String> = emptyList(),
-    var provideExtrasForEvent: (Map<ExtraKnownKey, String>) -> Map<ExtraKnownKey, String> = { emptyMap() },
+    var provideExtrasForEvent: (Map<ExtraKnownKey, String>) -> Map<ExtraKnownKey, String> = { currentExtras -> currentExtras },
     var applicationContext: Map<String, String> = emptyMap(),
 ) : CrashLoggingDataProvider {
 

--- a/AutomatticTracks/src/test/java/com/automattic/android/tracks/crashlogging/SentryCrashLoggingTest.kt
+++ b/AutomatticTracks/src/test/java/com/automattic/android/tracks/crashlogging/SentryCrashLoggingTest.kt
@@ -279,6 +279,16 @@ class SentryCrashLoggingTest {
     }
 
     @Test
+    fun `should return a null for extra key value if value is not applied`() {
+        val extraKey = "key"
+        initialize(extraKeys = listOf(extraKey))
+
+        val updatedEvent = beforeSendModifiedEvent(capturedOptions)
+
+        assertThat(requireNotNull(updatedEvent).getExtra(extraKey)).isNull()
+    }
+
+    @Test
     fun `should not modify events if the client disabled crash logging`() {
         initialize(crashLoggingEnabled = false)
         val testEvent: SentryEvent = mock()


### PR DESCRIPTION
Closes: #93 