### PR TITLE
Offer `SentryOkHttpInterceptor` to client

### DIFF
--- a/AutomatticTracks/build.gradle
+++ b/AutomatticTracks/build.gradle
@@ -11,6 +11,7 @@ repositories {
 
 dependencies {
     implementation 'io.sentry:sentry-android:5.0.0'
+    implementation 'io.sentry:sentry-android-okhttp:5.0.0'
     implementation 'androidx.annotation:annotation:1.1.0'
 
     testImplementation 'junit:junit:4.13.2'

--- a/AutomatticTracks/build.gradle
+++ b/AutomatticTracks/build.gradle
@@ -9,9 +9,13 @@ repositories {
     mavenCentral()
 }
 
+ext {
+    sentryVersion = "5.0.0"
+}
+
 dependencies {
-    implementation 'io.sentry:sentry-android:5.0.0'
-    implementation 'io.sentry:sentry-android-okhttp:5.0.0'
+    implementation "io.sentry:sentry-android:$sentryVersion"
+    implementation "io.sentry:sentry-android-okhttp:$sentryVersion"
     implementation 'androidx.annotation:annotation:1.1.0'
     implementation 'com.squareup.okhttp3:okhttp:4.9.0'
 

--- a/AutomatticTracks/build.gradle
+++ b/AutomatticTracks/build.gradle
@@ -28,7 +28,7 @@ android {
 
     defaultConfig {
         versionName "2.0.1"
-        minSdkVersion 16
+        minSdkVersion 21
         targetSdkVersion 30
         buildConfigField "String", "SENTRY_TEST_PROJECT_DSN", project.properties.get("sentryTestProjectDSN")
 

--- a/AutomatticTracks/build.gradle
+++ b/AutomatticTracks/build.gradle
@@ -13,6 +13,7 @@ dependencies {
     implementation 'io.sentry:sentry-android:5.0.0'
     implementation 'io.sentry:sentry-android-okhttp:5.0.0'
     implementation 'androidx.annotation:annotation:1.1.0'
+    implementation 'com.squareup.okhttp3:okhttp:4.9.0'
 
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.assertj:assertj-core:3.19.0'

--- a/AutomatticTracks/src/main/java/com/automattic/android/tracks/DeviceInformation.java
+++ b/AutomatticTracks/src/main/java/com/automattic/android/tracks/DeviceInformation.java
@@ -134,22 +134,13 @@ import java.util.Locale;
             mWidthPixels = mDisplayMetrics.widthPixels;
             mHeightPixels = mDisplayMetrics.heightPixels;
             // Try to load the real screen size now - This does include window decorations (statusbar bar/menu bar)
-            if (Build.VERSION.SDK_INT < 17) {
-                try {
-                    mWidthPixels = (int) Display.class.getMethod("getRawWidth").invoke(display);
-                    mHeightPixels = (int) Display.class.getMethod("getRawHeight").invoke(display);
-                } catch (Exception ignored) {
-                    Log.w(LOGTAG, "Unable to call getRawWidth/getRawHeight: " + ignored.getMessage());
-                }
-            } else {
-                try {
-                    Point realSize = new Point();
-                    display.getRealSize(realSize);
-                    mWidthPixels = realSize.x;
-                    mHeightPixels = realSize.y;
-                } catch (Exception ignored) {
-                    Log.w(LOGTAG, "Unable to call getRealSize: " + ignored.getMessage());
-                }
+            try {
+                Point realSize = new Point();
+                display.getRealSize(realSize);
+                mWidthPixels = realSize.x;
+                mHeightPixels = realSize.y;
+            } catch (final Exception exception) {
+                Log.w(LOGTAG, "Unable to call getRealSize: " + exception.getMessage());
             }
         }
 
@@ -371,12 +362,6 @@ import java.util.Locale;
     }
 
     public Boolean isBluetoothEnabled() {
-        // Do not retrieve bluetooth info on older Android versions.
-        // See: https://github.com/Automattic/Automattic-Tracks-Android/issues/20
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
-            return null;
-        }
-
         Boolean isBluetoothEnabled = null;
         if (PackageManager.PERMISSION_GRANTED == mContext.checkCallingOrSelfPermission(Manifest.permission.BLUETOOTH)) {
             BluetoothAdapter bluetoothAdapter = BluetoothAdapter.getDefaultAdapter();
@@ -389,8 +374,7 @@ import java.util.Locale;
 
     public String getBluetoothVersion() {
         String bluetoothVersion = "none";
-        if (Build.VERSION.SDK_INT >= 18 &&
-                mContext.getPackageManager().hasSystemFeature(PackageManager.FEATURE_BLUETOOTH_LE)) {
+        if (mContext.getPackageManager().hasSystemFeature(PackageManager.FEATURE_BLUETOOTH_LE)) {
             bluetoothVersion = "ble";
         } else if (mContext.getPackageManager().hasSystemFeature(PackageManager.FEATURE_BLUETOOTH)) {
             bluetoothVersion = "classic";
@@ -399,14 +383,10 @@ import java.util.Locale;
     }
 
     /**
-     * @return True if the default locale is Right-to-left, false otherwise. For SDK < 17 always returns false.
+     * @return True if the default locale is Right-to-left, false otherwise.
      */
     public boolean isRtlLanguage() {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
-            return TextUtils.getLayoutDirectionFromLocale(mLocale) == View.LAYOUT_DIRECTION_RTL;
-        } else {
-            return false;
-        }
+        return TextUtils.getLayoutDirectionFromLocale(mLocale) == View.LAYOUT_DIRECTION_RTL;
     }
 
     public String getDeviceLanguage() {

--- a/AutomatticTracks/src/main/java/com/automattic/android/tracks/NetworkUtils.java
+++ b/AutomatticTracks/src/main/java/com/automattic/android/tracks/NetworkUtils.java
@@ -61,15 +61,7 @@ public class NetworkUtils {
     /**
      * returns true if airplane mode has been enabled
      */
-    @TargetApi(VERSION_CODES.JELLY_BEAN_MR1)
-    @SuppressWarnings("deprecation")
     public static boolean isAirplaneModeOn(Context context) {
-        // prior to JellyBean 4.2 this was Settings.System.AIRPLANE_MODE_ON, JellyBean 4.2
-        // moved it to Settings.Global
-        if (Build.VERSION.SDK_INT < VERSION_CODES.JELLY_BEAN_MR1) {
-            return Settings.System.getInt(context.getContentResolver(), Settings.System.AIRPLANE_MODE_ON, 0) != 0;
-        } else {
-            return Settings.Global.getInt(context.getContentResolver(), Settings.Global.AIRPLANE_MODE_ON, 0) != 0;
-        }
+        return Settings.Global.getInt(context.getContentResolver(), Settings.Global.AIRPLANE_MODE_ON, 0) != 0;
     }
 }

--- a/AutomatticTracks/src/main/java/com/automattic/android/tracks/crashlogging/CrashLoggingOkHttpInterceptorProvider.kt
+++ b/AutomatticTracks/src/main/java/com/automattic/android/tracks/crashlogging/CrashLoggingOkHttpInterceptorProvider.kt
@@ -1,7 +1,8 @@
 package com.automattic.android.tracks.crashlogging
 
 import io.sentry.android.okhttp.SentryOkHttpInterceptor
+import okhttp3.Interceptor
 
 object CrashLoggingOkHttpInterceptorProvider {
-    fun createInstance(): SentryOkHttpInterceptor = SentryOkHttpInterceptor()
+    fun createInstance(): Interceptor = SentryOkHttpInterceptor()
 }

--- a/AutomatticTracks/src/main/java/com/automattic/android/tracks/crashlogging/CrashLoggingOkHttpInterceptorProvider.kt
+++ b/AutomatticTracks/src/main/java/com/automattic/android/tracks/crashlogging/CrashLoggingOkHttpInterceptorProvider.kt
@@ -1,0 +1,7 @@
+package com.automattic.android.tracks.crashlogging
+
+import io.sentry.android.okhttp.SentryOkHttpInterceptor
+
+object CrashLoggingOkHttpInterceptorProvider {
+    fun createInstance(): SentryOkHttpInterceptor = SentryOkHttpInterceptor()
+}

--- a/sampletracksapp/build.gradle
+++ b/sampletracksapp/build.gradle
@@ -12,7 +12,7 @@ android {
 
     defaultConfig {
         applicationId "com.example.sampletracksapp"
-        minSdkVersion 16
+        minSdkVersion 21
         targetSdkVersion 30
         buildConfigField "String", "SENTRY_TEST_PROJECT_DSN", project.properties.get("sentryTestProjectDSN")
 


### PR DESCRIPTION
Closes: #90 

This PR adds a feature of offering `SentryOkHttpInterceptor` outside the library. Integrating this interceptor adds some features to crash reporting like automatically added network-related breadcrumbs or performance logs:

### Sample
<img width="1927" alt="Screenshot 2021-06-07 at 14 51 13" src="https://user-images.githubusercontent.com/5845095/121027007-eaa34800-c7a6-11eb-92a8-2bde0f6cee9e.png">

Because of `sentry-android-okhttp` dependency, I had to set `minSdk` to `21` and this required removing some conditional code.

I think bumping `minSdk` is not a problem as all clients use version `21` or higher: 
- [WPAndroid](https://github.com/wordpress-mobile/WordPress-Android/blob/develop/build.gradle#L121)
- [WCAndroid](https://github.com/woocommerce/woocommerce-android/blob/develop/WooCommerce/build.gradle#L59)
- [simplenote-android](https://github.com/Automattic/simplenote-android/blob/develop/Simplenote/build.gradle#L36)