### PR TITLE
Release 2.1.0

### DIFF
--- a/AutomatticTracks/build.gradle
+++ b/AutomatticTracks/build.gradle
@@ -30,7 +30,7 @@ android {
     compileSdkVersion 30
 
     defaultConfig {
-        versionName "2.0.1"
+        versionName "2.1.0"
         minSdkVersion 21
         targetSdkVersion 30
         buildConfigField "String", "SENTRY_TEST_PROJECT_DSN", project.properties.get("sentryTestProjectDSN")


### PR DESCRIPTION
- Updating Sentry SDK from `4.3.0` to `5.0.1`
- Offer `SentryOkHttpInterceptor` #97 