### PR TITLE
Change Sentry version variable to fix `Dependabot`. Bump Sentry to `5.4.3`.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,4 +5,4 @@ updates:
     schedule:
       interval: "daily"
     allow:
-      - dependency-name: "io.sentry:sentry-android"
+      - dependency-name: "io.sentry:sentry-bom"

--- a/AutomatticTracks/build.gradle
+++ b/AutomatticTracks/build.gradle
@@ -10,7 +10,7 @@ repositories {
 }
 
 dependencies {
-    implementation platform('io.sentry:sentry-bom:5.0.1')
+    implementation platform('io.sentry:sentry-bom:5.4.3')
     implementation "io.sentry:sentry-android"
     implementation "io.sentry:sentry-android-okhttp"
     implementation 'androidx.annotation:annotation:1.1.0'

--- a/AutomatticTracks/build.gradle
+++ b/AutomatticTracks/build.gradle
@@ -10,8 +10,9 @@ repositories {
 }
 
 dependencies {
-    implementation "io.sentry:sentry-android:5.0.1"
-    implementation "io.sentry:sentry-android-okhttp:5.0.1"
+    implementation platform('io.sentry:sentry-bom:5.0.1')
+    implementation "io.sentry:sentry-android"
+    implementation "io.sentry:sentry-android-okhttp"
     implementation 'androidx.annotation:annotation:1.1.0'
     implementation 'com.squareup.okhttp3:okhttp:4.9.0'
 

--- a/AutomatticTracks/build.gradle
+++ b/AutomatticTracks/build.gradle
@@ -10,10 +10,8 @@ repositories {
 }
 
 dependencies {
-    def sentryVersion = "5.0.1"
-
-    implementation "io.sentry:sentry-android:$sentryVersion"
-    implementation "io.sentry:sentry-android-okhttp:$sentryVersion"
+    implementation "io.sentry:sentry-android:5.0.1"
+    implementation "io.sentry:sentry-android-okhttp:5.0.1"
     implementation 'androidx.annotation:annotation:1.1.0'
     implementation 'com.squareup.okhttp3:okhttp:4.9.0'
 


### PR DESCRIPTION
Closes: #104 

You can see result in fork: https://github.com/wzieba/Automattic-Tracks-Android/pulls