### PR TITLE
Adds Buildkite & Publishing to S3

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,0 +1,25 @@
+common-params:
+  &docker-container
+  docker#v3.8.0:
+    image: "public.ecr.aws/automattic/android-build-image:v1.2.0"
+    propagate-environment: true
+
+steps:
+  - label: "Lint"
+    key: "lint"
+    plugins:
+      - *docker-container
+    command: |
+      cp gradle.properties-example gradle.properties
+      ./gradlew lintRelease ciktlint
+    artifact_paths:
+      - "**/build/reports/lint-results.*"
+      - "**/build/ktlint.xml"
+
+  - label: "Test"
+    key: "test"
+    plugins:
+      - *docker-container
+    command: |
+      cp gradle.properties-example gradle.properties
+      ./gradlew test

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -3,6 +3,12 @@ common-params:
   docker#v3.8.0:
     image: "public.ecr.aws/automattic/android-build-image:v1.2.0"
     propagate-environment: true
+    propagate-environment: true
+    environment:
+      # DO NOT MANUALLY SET THESE VALUES!
+      # They are passed from the Buildkite agent to the Docker container
+      - "AWS_ACCESS_KEY"
+      - "AWS_SECRET_KEY"
 
 steps:
   - label: "Lint"
@@ -23,3 +29,18 @@ steps:
     command: |
       cp gradle.properties-example gradle.properties
       ./gradlew test
+
+  - label: "Publish {{matrix}} to S3"
+    depends_on:
+      - "lint"
+      - "test"
+    plugins:
+      - *docker-container
+    matrix:
+      - AutomatticTracks
+      - experimentation
+    command: |
+      cp gradle.properties-example gradle.properties
+      ./gradlew \
+          :{{matrix}}:prepareToPublishToS3 $(prepare_to_publish_to_s3_params) \
+          :{{matrix}}:publish

--- a/AutomatticTracks/build.gradle
+++ b/AutomatticTracks/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'com.android.library'
     id 'org.jetbrains.kotlin.android'
-    id 'maven-publish'
+    id 'com.automattic.android.publish-to-s3'
 }
 
 repositories {
@@ -63,10 +63,14 @@ afterEvaluate {
     publishing {
         publications {
             maven(MavenPublication) {
-                artifactId 'Automattic-Tracks-Android'
-                description 'Android client for Nosara tracks (event tracking and analytics)'
                 from components.release
+
                 groupId 'com.automattic'
+                artifactId 'Automattic-Tracks-Android'
+                artifact tasks.named("androidSourcesJar")
+                // version is set by 'publish-to-s3' plugin
+
+                description 'Android client for Nosara tracks (event tracking and analytics)'
                 pom {
                     licenses {
                         license {

--- a/AutomatticTracks/build.gradle
+++ b/AutomatticTracks/build.gradle
@@ -67,7 +67,6 @@ afterEvaluate {
 
                 groupId 'com.automattic'
                 artifactId 'Automattic-Tracks-Android'
-                artifact tasks.named("androidSourcesJar")
                 // version is set by 'publish-to-s3' plugin
 
                 description 'Android client for Nosara tracks (event tracking and analytics)'

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Automattic-Tracks-Android [![CircleCI](https://circleci.com/gh/Automattic/Automattic-Tracks-Android.svg?style=shield)](https://app.circleci.com/pipelines/github/Automattic/Automattic-Tracks-Android) [![Releases](https://img.shields.io/github/v/release/Automattic/Automattic-Tracks-Android)](https://github.com/Automattic/Automattic-Tracks-Android/releases)
+# Automattic-Tracks-Android
 Client library for tracking user events for later analysis
 
 ## Introduction
@@ -11,15 +11,39 @@ projects but the idea is to share what we've made.
 
 ## Build
 
-* Build:
-
 ```sh
 $ ./gradlew assemble
 ```
 
 ## Usage
 
-Follow instructions under `How to` section on [jitpack.com/Automattic/Automattic-Tracks-Android](https://jitpack.io/#Automattic/Automattic-Tracks-Android/)
+```groovy
+repositories {
+    maven {
+        url 'https://a8c-libs.s3.amazonaws.com/android'
+        content {
+            includeGroup 'com.automattic'
+            includeGroup 'com.automattic.tracks'
+        }
+    }
+}
+
+dependencies {
+    // For 'tracks' module
+    implementation 'com.automattic:Automattic-Tracks-Android:{version}'
+
+    // For 'experimentation' module
+    implementation 'com.automattic.tracks:experimentation:{version}'
+}
+```
+
+## Publishing a new version
+
+In the following cases, the CI will publish a new version with the following format to our S3 Maven repo:
+
+* For each commit in an open PR: `<PR-number>-<commit full SHA1>`
+* Each time a PR is merged to `trunk`: `trunk-<commit full SHA1>`
+* Each time a new tag is created: `{tag-name}`
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -9,12 +9,6 @@ storing them locally, and on a schedule send them out to the Automattic
 servers. Realistically this library is only useful for Automattic-based
 projects but the idea is to share what we've made.
 
-## Build
-
-```sh
-$ ./gradlew assemble
-```
-
 ## Usage
 
 ```groovy

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,8 @@
+plugins {
+    id 'com.android.library' apply false
+    id 'org.jetbrains.kotlin.android' apply false
+}
+
 subprojects {
 
     repositories {

--- a/experimentation/build.gradle
+++ b/experimentation/build.gradle
@@ -60,7 +60,6 @@ afterEvaluate {
 
                 groupId 'com.automattic.tracks'
                 artifactId 'experimentation'
-                artifact tasks.named("androidSourcesJar")
                 // version is set by 'publish-to-s3' plugin
             }
         }

--- a/experimentation/build.gradle
+++ b/experimentation/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id 'com.android.library'
     id 'org.jetbrains.kotlin.android'
+    id 'com.automattic.android.publish-to-s3'
 }
 
 repositories {
@@ -50,3 +51,19 @@ dependencies {
     testImplementation 'org.mockito.kotlin:mockito-kotlin:2.2.11'
     testImplementation 'org.mockito:mockito-inline:3.8.0'
 }
+
+afterEvaluate {
+    publishing {
+        publications {
+            maven(MavenPublication) {
+                from components.release
+
+                groupId 'com.automattic.tracks'
+                artifactId 'experimentation'
+                artifact tasks.named("androidSourcesJar")
+                // version is set by 'publish-to-s3' plugin
+            }
+        }
+    }
+}
+

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,14 +1,14 @@
 pluginManagement {
     plugins {
         id 'org.jetbrains.kotlin.android' version '1.4.31'
-        id "com.automattic.android.publish-to-s3" version "0.7.0"
+        id 'com.automattic.android.publish-to-s3' version '0.7.0'
     }
     repositories {
         maven {
             url 'https://a8c-libs.s3.amazonaws.com/android' 
             content {
-                includeGroup "com.automattic.android"
-                includeGroup "com.automattic.android.publish-to-s3"
+                includeGroup 'com.automattic.android'
+                includeGroup 'com.automattic.android.publish-to-s3'
             }
         }
         google()

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,8 +1,16 @@
 pluginManagement {
     plugins {
         id 'org.jetbrains.kotlin.android' version '1.4.31'
+        id "com.automattic.android.publish-to-s3" version "0.7.0"
     }
     repositories {
+        maven {
+            url 'https://a8c-libs.s3.amazonaws.com/android' 
+            content {
+                includeGroup "com.automattic.android"
+                includeGroup "com.automattic.android.publish-to-s3"
+            }
+        }
         google()
         gradlePluginPortal()
     }


### PR DESCRIPTION
This PR adds Buildkite and publishing to S3 following the conventions we have in other projects. Unfortunately both Gradle and Android Gradle Plugin are outdated in this project which meant that I was not able to add publishing sources as part of this PR. Instead of trying to combine that into this PR, I think it'll be better to review & merge this PR as is and add publishing the sources after we have a chance to upgrade Gradle & Android Gradle Plugin.

The CircleCI failure is due to this PR adding `publish-to-s3` Gradle plugin as the `publishToMavenLocal` requires the plugin to be configured. I've already added all the necessary tasks from CircleCI to the new Buildkite configuration, so we can ignore the error and remove CircleCI in a subsequent PR.

I've updated the `README` with the new publishing & usage instructions. I'll open client PRs to update their usage once this PR is merged.

**To Test:**

As long as Buildkite is green, we should be good for this PR. If there are any issues during usage, which is not very likely, I'll follow up with it as a follow up PR.