### PR TITLE
Add tracking for font-sizing related info.

### DIFF
--- a/AutomatticTracks/src/main/java/com/automattic/android/tracks/DeviceInformation.java
+++ b/AutomatticTracks/src/main/java/com/automattic/android/tracks/DeviceInformation.java
@@ -185,6 +185,18 @@ import java.util.Locale;
             Log.e(LOGTAG, "Exception writing display_density_dpi value in JSON object", e);
         }
         try {
+            // Track font-sizing related values.
+            // - fontScale: user preference for scaling factor. See: https://developer.android.com/reference/android/content/res/Configuration.html#fontScale
+            // - scaledDensity: density * fontScale. See: http://androidxref.com/4.2_r1/xref/packages/apps/Settings/src/com/android/settings/Display.java#99
+            double fontScale = mContext.getResources().getConfiguration().fontScale;
+            double scaledDensity = getDisplayMetrics().scaledDensity;
+            mImmutableDeviceInfoJSON.put("font_scale", fontScale);
+            mImmutableDeviceInfoJSON.put("scaled_density", scaledDensity);
+        } catch (final JSONException e) {
+            Log.e(LOGTAG, "Exception writing font sizing values in JSON object", e);
+        }
+
+        try {
             // Width and height depend on device orientation - to be consistent, always
             // report the shorter dimension as the width.
             // These values represent the 'real' dimensions of the screen, ignoring navigation


### PR DESCRIPTION
To solve https://github.com/woocommerce/woocommerce-android/issues/7282

This adds the following data:

- fontScale
- scaledDensity

The goal is so we know how many users set the font super high and be affected by display oddities with larger fonts.

I'm not yet sure how different `fontScale` and `scaledDensity` values will be on different type of screen out there, and whether one or the other is enough to determine how big the font is set by the user. So I thought it'd be safer to get both.

I am not sure how to test this but previous PRs like https://github.com/Automattic/Automattic-Tracks-Android/pull/40 that does similar thing does not seem to include any.

@wzieba if I understand correctly from the `build.gradle` file in WCAndroid, we just use `com.automattic:Automattic-Tracks-Android:trunk-<commit full SHA1>`. So there's nothing specific here to do after this is PR is merged, just add the change in WCAndroid?