### PR TITLE
Add user type for Day One

### DIFF
--- a/AutomatticTracks/src/main/java/com/automattic/android/tracks/MessageBuilder.java
+++ b/AutomatticTracks/src/main/java/com/automattic/android/tracks/MessageBuilder.java
@@ -23,7 +23,6 @@ class MessageBuilder {
     private static final String USER_TYPE_WPCOM = "wpcom:user_id";
     private static final String USER_TYPE_SIMPLENOTE = "simplenote:user_id";
     private static final String USER_TYPE_POCKETCASTS = "pocketcasts:user_id";
-
     private static final String USER_TYPE_DAYONE = "dayone:user_id";
     private static final String USER_ID_KEY = "_ui";
     private static final String USER_LANG_KEY = "_lg";

--- a/AutomatticTracks/src/main/java/com/automattic/android/tracks/MessageBuilder.java
+++ b/AutomatticTracks/src/main/java/com/automattic/android/tracks/MessageBuilder.java
@@ -23,6 +23,8 @@ class MessageBuilder {
     private static final String USER_TYPE_WPCOM = "wpcom:user_id";
     private static final String USER_TYPE_SIMPLENOTE = "simplenote:user_id";
     private static final String USER_TYPE_POCKETCASTS = "pocketcasts:user_id";
+
+    private static final String USER_TYPE_DAYONE = "dayone:user_id";
     private static final String USER_ID_KEY = "_ui";
     private static final String USER_LANG_KEY = "_lg";
     private static final String USER_LOGIN_NAME_KEY = "_ul";
@@ -109,6 +111,9 @@ class MessageBuilder {
                 case POCKETCASTS:
                     eventJSON.put(USER_ID_KEY, event.getUser());
                     eventJSON.put(USER_TYPE_KEY, USER_TYPE_POCKETCASTS);
+                case DAYONE:
+                    eventJSON.put(USER_ID_KEY, event.getUser());
+                    eventJSON.put(USER_TYPE_KEY, USER_TYPE_DAYONE);
             }
 
             unfolderPropertiesNotAvailableInCommon(event.getUserProperties(), USER_INFO_PREFIX, eventJSON, commonProps);

--- a/AutomatticTracks/src/main/java/com/automattic/android/tracks/TracksClient.java
+++ b/AutomatticTracks/src/main/java/com/automattic/android/tracks/TracksClient.java
@@ -38,7 +38,7 @@ public class TracksClient {
     protected static final int DEFAULT_EVENTS_QUEUE_TIMER_MS = 30000;
     protected static final int DEFAULT_EVENT_MAX_AGE = 14 * 24 * 60 * 60 * 1000 ; // 14 days
 
-    public static enum NosaraUserType {ANON, WPCOM, SIMPLENOTE, POCKETCASTS}
+    public static enum NosaraUserType {ANON, WPCOM, SIMPLENOTE, POCKETCASTS, DAYONE}
 
     /**
      * Socket timeout in milliseconds for rest requests


### PR DESCRIPTION
We are adding Tracks to Day One Android application. This PR adds a corresponding user type.

`dayone:user_id` is already whitelisted  [here](https://github.com/Automattic/nosara/blob/master/wyeast_streaming/src/main/resources/tracks/whitelists/tracks_useridtype_whitelist.config).

There is nothing to test.