### PR TITLE
feat: allow to specify profiling sampling

### DIFF
--- a/AutomatticTracks/src/main/java/com/automattic/android/tracks/crashlogging/CrashLoggingDataProvider.kt
+++ b/AutomatticTracks/src/main/java/com/automattic/android/tracks/crashlogging/CrashLoggingDataProvider.kt
@@ -88,10 +88,18 @@ sealed class PerformanceMonitoringConfig {
          * Provides sample rate for performance monitoring. Indicates how often do we measure performance.
          * Has to be between 0 and 1.
          */
-        val sampleRate: Double
+        val sampleRate: Double,
+        /**
+         * Provides sample rate for recording profiles.
+         * Indicates how often do we record profile for a performance transaction.
+         * Mind that this value is **relative** to [sampleRate] value.
+         * Has to be between 0 and 1.
+         */
+        val profilesSampleRate: Double = 0.0
     ) : PerformanceMonitoringConfig() {
         init {
             assert(sampleRate in 0.0..1.0)
+            assert(profilesSampleRate in 0.0..1.0)
         }
     }
 }

--- a/AutomatticTracks/src/main/java/com/automattic/android/tracks/crashlogging/internal/SentryCrashLogging.kt
+++ b/AutomatticTracks/src/main/java/com/automattic/android/tracks/crashlogging/internal/SentryCrashLogging.kt
@@ -27,15 +27,20 @@ internal class SentryCrashLogging constructor(
 
     init {
         sentryWrapper.initialize(application) { options ->
+
+            val (tracesSampleRate, profilesSampleRate) = dataProvider.performanceMonitoringConfig.let {
+                when (it) {
+                    Disabled -> null to null
+                    is Enabled -> it.sampleRate to it.profilesSampleRate
+                }
+            }
+
             options.apply {
                 dsn = dataProvider.sentryDSN
                 environment = dataProvider.buildType
                 release = dataProvider.releaseName
-                tracesSampleRate =
-                    when (val perfConfig = dataProvider.performanceMonitoringConfig) {
-                        Disabled -> null
-                        is Enabled -> perfConfig.sampleRate
-                    }
+                this.tracesSampleRate = tracesSampleRate
+                this.profilesSampleRate = profilesSampleRate
                 isDebug = dataProvider.enableCrashLoggingLogs
                 setTag("locale", dataProvider.locale?.language ?: "unknown")
                 setBeforeBreadcrumb { breadcrumb, _ ->

--- a/sampletracksapp/src/main/java/com/example/sampletracksapp/MainActivity.kt
+++ b/sampletracksapp/src/main/java/com/example/sampletracksapp/MainActivity.kt
@@ -41,7 +41,7 @@ class MainActivity : AppCompatActivity() {
                 override val releaseName = "test"
                 override val locale = Locale.US
                 override val enableCrashLoggingLogs = true
-                override val performanceMonitoringConfig = PerformanceMonitoringConfig.Enabled(1.0)
+                override val performanceMonitoringConfig = PerformanceMonitoringConfig.Enabled(sampleRate = 1.0, profilesSampleRate = 1.0)
                 override val user = flowOf(
                     CrashLoggingUser(
                         userID = "test user id",


### PR DESCRIPTION
### Description

This PR adds `profilesSampleRate` to Sentry Performance configuration, which allows enabling the Sentry Profiling feature.

The default value is 0.0, which disables this feature for backwards compatibility.

### How to test

1. Add property with the name `sentryTestProjectDSN` to `gradle.properties` with the value of the DSN of `tracks-demo-android` project (you can find it in the Sentry dashboard).
2. Run the test app
3. Press "Measure performance of sample..."
4. Go to the Profiles tab in Sentry (make sure you've selected `tracks-demo-android` project)
5. Make sure that after a few seconds, the new profile has been uploaded