### PR TITLE
Update dependabot.yml to check in main directory

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,7 @@
 version: 2
 updates:
   - package-ecosystem: "gradle"
-    directory: "AutomatticTracks/"
+    directory: "/"
     schedule:
       interval: "daily"
     allow:


### PR DESCRIPTION
After centralizing version numbers, the version is no longer available directly in AutomatticTracks/build.gradle file, but rather in /build.gradle.

See https://github.com/Automattic/Automattic-Tracks-Android/pull/187#issuecomment-1662492428