### PR TITLE
[Nullability Annotations to Java Classes] Add `wordpress.lint` Dependency

### DIFF
--- a/AutomatticTracks/build.gradle
+++ b/AutomatticTracks/build.gradle
@@ -11,7 +11,6 @@ repositories {
         url "https://a8c-libs.s3.amazonaws.com/android"
         content {
             includeGroup "org.wordpress"
-            includeGroup "org.wordpress.lint"
         }
     }
 }

--- a/AutomatticTracks/build.gradle
+++ b/AutomatticTracks/build.gradle
@@ -7,6 +7,13 @@ plugins {
 repositories {
     google()
     mavenCentral()
+    maven {
+        url "https://a8c-libs.s3.amazonaws.com/android"
+        content {
+            includeGroup "org.wordpress"
+            includeGroup "org.wordpress.lint"
+        }
+    }
 }
 
 dependencies {
@@ -23,6 +30,8 @@ dependencies {
     testImplementation "org.mockito.kotlin:mockito-kotlin:$mockitoKotlinVersion"
     testImplementation "org.mockito:mockito-inline:$mockitoInlineVersion"
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$kotlinxCoroutinesVersion"
+
+    lintChecks "org.wordpress:lint:$wordpressLintVersion"
 }
 
 android {

--- a/build.gradle
+++ b/build.gradle
@@ -57,4 +57,7 @@ ext {
     junitVersion = '4.13.2'
     mockitoInlineVersion = '4.8.1'
     mockitoKotlinVersion = '4.0.0'
+
+    // other
+    wordpressLintVersion = '2.0.0'
 }


### PR DESCRIPTION
This PR adds `wordPress-lint` checks to the project ([2.0.0](https://github.com/wordpress-mobile/WordPress-Lint-Android/releases/tag/2.0.0)).

-----

## To test:

1. Verifying that all the CI checks are successful (focus on the Lint related [check](https://buildkite.com/automattic/automattic-tracks-android/builds/191#018b61d2-63fd-4d59-aa7f-1e00f5bd7235) and its [report](N/A)).
2. Verify that the new `MissingNullAnnotationOn*` correctness related rules are reporting as expected. For a reference, see screenshot below:

![image](https://github.com/Automattic/Automattic-Tracks-Android/assets/9729923/a6039b59-d9e3-4071-9ff6-4aba8c827639)
