### PR TITLE
[Lib] Update targetSdk from 33 to 34.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ subprojects {
 ext {
     minSdkVersion = 21
     compileSdkVersion = 34
-    targetSdkVersion = 33
+    targetSdkVersion = 34
 }
 
 


### PR DESCRIPTION
Issue: https://github.com/Automattic/Automattic-Tracks-Android/issues/199

## What

This PR updates the `targetSdk` from 33 to 34. This is in preparation for the Android 14 update.

## Test

- [x] Test using the build generated here: https://github.com/wordpress-mobile/WordPress-Android/pull/20364.
- [x] Make sure you still see tracks logs in logcat.