### PR TITLE
Add support to send JS exceptions to Sentry

### DIFF
--- a/AutomatticTracks/src/main/java/com/automattic/android/tracks/crashlogging/CrashLogging.kt
+++ b/AutomatticTracks/src/main/java/com/automattic/android/tracks/crashlogging/CrashLogging.kt
@@ -1,7 +1,6 @@
 package com.automattic.android.tracks.crashlogging
 
 interface CrashLogging {
-
     /**
      * Records a breadcrumb during the app lifecycle but doesn't report an event. This basically
      * adds more context for the next reports created and sent by [sendReport] or an unhandled
@@ -39,5 +38,10 @@ interface CrashLogging {
         exception: Throwable? = null,
         tags: Map<String, String> = emptyMap(),
         message: String? = null
+    )
+
+    fun sendJavaScriptReport(
+        jsException: JsException,
+        callback: JsExceptionCallback
     )
 }

--- a/AutomatticTracks/src/main/java/com/automattic/android/tracks/crashlogging/JsException.kt
+++ b/AutomatticTracks/src/main/java/com/automattic/android/tracks/crashlogging/JsException.kt
@@ -1,0 +1,23 @@
+package com.automattic.android.tracks.crashlogging
+
+
+data class JsException(
+    val type: String,
+    val message: String,
+    var stackTrace: List<JsExceptionStackTraceElement>,
+    val context: Map<String, Any>,
+    val tags: Map<String, String>,
+    val isHandled: Boolean,
+    val handledBy: String,
+)
+
+data class JsExceptionStackTraceElement (
+    val fileName: String,
+    val lineNumber: Int,
+    val colNumber: Int,
+    val function: String,
+)
+
+interface JsExceptionCallback {
+    fun onReportSent(sent:Boolean)
+}

--- a/AutomatticTracks/src/main/java/com/automattic/android/tracks/crashlogging/JsException.kt
+++ b/AutomatticTracks/src/main/java/com/automattic/android/tracks/crashlogging/JsException.kt
@@ -1,6 +1,5 @@
 package com.automattic.android.tracks.crashlogging
 
-
 data class JsException(
     val type: String,
     val message: String,
@@ -8,16 +7,16 @@ data class JsException(
     val context: Map<String, Any>,
     val tags: Map<String, String>,
     val isHandled: Boolean,
-    val handledBy: String,
+    val handledBy: String
 )
 
-data class JsExceptionStackTraceElement (
+data class JsExceptionStackTraceElement(
     val fileName: String,
     val lineNumber: Int,
     val colNumber: Int,
-    val function: String,
+    val function: String
 )
 
 interface JsExceptionCallback {
-    fun onReportSent(sent:Boolean)
+    fun onReportSent(sent: Boolean)
 }

--- a/AutomatticTracks/src/main/java/com/automattic/android/tracks/crashlogging/JsException.kt
+++ b/AutomatticTracks/src/main/java/com/automattic/android/tracks/crashlogging/JsException.kt
@@ -11,9 +11,9 @@ data class JsException(
 )
 
 data class JsExceptionStackTraceElement(
-    val fileName: String,
-    val lineNumber: Int,
-    val colNumber: Int,
+    val fileName: String?,
+    val lineNumber: Int?,
+    val colNumber: Int?,
     val function: String
 )
 

--- a/AutomatticTracks/src/main/java/com/automattic/android/tracks/crashlogging/internal/SentryCrashLogging.kt
+++ b/AutomatticTracks/src/main/java/com/automattic/android/tracks/crashlogging/internal/SentryCrashLogging.kt
@@ -151,6 +151,7 @@ internal class SentryCrashLogging constructor(
                 this.function = it.function
                 this.lineno = it.lineNumber
                 this.colno = it.colNumber
+                this.isInApp = true
             }
         }.toMutableList()
 

--- a/AutomatticTracks/src/main/java/com/automattic/android/tracks/crashlogging/internal/SentryCrashLogging.kt
+++ b/AutomatticTracks/src/main/java/com/automattic/android/tracks/crashlogging/internal/SentryCrashLogging.kt
@@ -146,7 +146,7 @@ internal class SentryCrashLogging constructor(
         callback: JsExceptionCallback
     ) {
         val frames = jsException.stackTrace.map {
-           SentryStackFrame().apply {
+            SentryStackFrame().apply {
                 this.filename = it.fileName
                 this.function = it.function
                 this.lineno = it.lineNumber
@@ -167,7 +167,7 @@ internal class SentryCrashLogging constructor(
 
         val event = SentryEvent().apply {
             this.message = Message().apply { this.message = message }
-            this.level =  SentryLevel.FATAL
+            this.level = SentryLevel.FATAL
             this.platform = "javascript"
             this.appendTags(jsException.tags)
             this.exceptions = mutableListOf(sentryException)

--- a/AutomatticTracks/src/main/java/com/automattic/android/tracks/crashlogging/internal/SentryCrashLogging.kt
+++ b/AutomatticTracks/src/main/java/com/automattic/android/tracks/crashlogging/internal/SentryCrashLogging.kt
@@ -11,7 +11,6 @@ import com.automattic.android.tracks.crashlogging.PerformanceMonitoringConfig.Di
 import com.automattic.android.tracks.crashlogging.PerformanceMonitoringConfig.Enabled
 import com.automattic.android.tracks.crashlogging.eventLevel
 import io.sentry.Breadcrumb
-import io.sentry.Scope
 import io.sentry.Sentry
 import io.sentry.SentryEvent
 import io.sentry.SentryLevel
@@ -174,7 +173,7 @@ internal class SentryCrashLogging constructor(
             this.exceptions = mutableListOf(sentryException)
         }
 
-        Sentry.configureScope { scope: Scope ->
+        Sentry.configureScope { scope ->
             scope.setContexts("react_native_context", jsException.context)
         }
         sentryWrapper.captureEvent(event)

--- a/sampletracksapp/src/main/java/com/example/sampletracksapp/MainActivity.kt
+++ b/sampletracksapp/src/main/java/com/example/sampletracksapp/MainActivity.kt
@@ -95,7 +95,7 @@ class MainActivity : AppCompatActivity() {
             sendReportWithJavaScriptException.setOnClickListener {
                 val callback = object : JsExceptionCallback {
                     override fun onReportSent(sent: Boolean) {
-                       Log.d("JsExceptionCallback", "onReportSent: $sent")
+                        Log.d("JsExceptionCallback", "onReportSent: $sent")
                     }
                 }
                 val jsException = JsException(

--- a/sampletracksapp/src/main/java/com/example/sampletracksapp/MainActivity.kt
+++ b/sampletracksapp/src/main/java/com/example/sampletracksapp/MainActivity.kt
@@ -1,6 +1,7 @@
 package com.example.sampletracksapp
 
 import android.os.Bundle
+import android.util.Log
 import androidx.appcompat.app.AppCompatActivity
 import com.automattic.android.tracks.crashlogging.CrashLoggingDataProvider
 import com.automattic.android.tracks.crashlogging.CrashLoggingOkHttpInterceptorProvider
@@ -8,6 +9,9 @@ import com.automattic.android.tracks.crashlogging.CrashLoggingProvider
 import com.automattic.android.tracks.crashlogging.CrashLoggingUser
 import com.automattic.android.tracks.crashlogging.EventLevel
 import com.automattic.android.tracks.crashlogging.ExtraKnownKey
+import com.automattic.android.tracks.crashlogging.JsException
+import com.automattic.android.tracks.crashlogging.JsExceptionCallback
+import com.automattic.android.tracks.crashlogging.JsExceptionStackTraceElement
 import com.automattic.android.tracks.crashlogging.PerformanceMonitoringConfig
 import com.automattic.android.tracks.crashlogging.RequestFormatter
 import com.automattic.android.tracks.crashlogging.performance.PerformanceMonitoringRepositoryProvider
@@ -26,7 +30,6 @@ import java.io.IOException
 import java.util.Locale
 
 class MainActivity : AppCompatActivity() {
-
     val transactionRepository: PerformanceTransactionRepository =
         PerformanceMonitoringRepositoryProvider.createInstance()
 
@@ -87,6 +90,31 @@ class MainActivity : AppCompatActivity() {
 
             sendReportWithException.setOnClickListener {
                 crashLogging.sendReport(exception = Exception("Exception from Tracks test app"))
+            }
+
+            sendReportWithJavaScriptException.setOnClickListener {
+                val callback = object : JsExceptionCallback {
+                    override fun onReportSent(sent: Boolean) {
+                       Log.d("JsExceptionCallback", "onReportSent: $sent")
+                    }
+                }
+                val jsException = JsException(
+                    type = "Error",
+                    message = "JavaScript exception from Tracks test app",
+                    stackTrace = listOf(
+                        JsExceptionStackTraceElement(
+                            fileName = "file.js",
+                            lineNumber = 1,
+                            colNumber = 1,
+                            function = "function"
+                        )
+                    ),
+                    context = mapOf("context" to "value"),
+                    tags = mapOf("tag" to "SomeTag"),
+                    isHandled = true,
+                    handledBy = "SomeHandler"
+                )
+                crashLogging.sendJavaScriptReport(jsException, callback)
             }
 
             recordBreadcrumbWithMessage.setOnClickListener {

--- a/sampletracksapp/src/main/res/layout/activity_main.xml
+++ b/sampletracksapp/src/main/res/layout/activity_main.xml
@@ -20,6 +20,12 @@
         android:layout_height="wrap_content"
         android:text="Send report with exception" />
 
+    <Button
+        android:id="@+id/sendReportWithJavaScriptException"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Send report with JS exception" />
+
     <View
         android:layout_width="match_parent"
         android:layout_height="1dp"


### PR DESCRIPTION
**Related Changes:** 
- https://github.com/wordpress-mobile/WordPress-Android/pull/20359

This PR expands the Crash logging service to support logging JavaScript exceptions to Sentry. This will allow hybrid sources like React Native (used in Gutenberg Mobile) to log exceptions with detailed information and symbolicated stack traces, which will greatly simplify the crash debugging process.

### To test

Since it involves testing exceptions, we need to modify the code to force them and generate an installable build. A test PR has been created for this purpose, follow the testing instructions from https://github.com/wordpress-mobile/gutenberg-mobile/pull/6654.