### PR TITLE
Remove CrashLoggingDataProvider.releaseName

### DIFF
--- a/AutomatticTracks/src/main/java/com/automattic/android/tracks/crashlogging/CrashLoggingDataProvider.kt
+++ b/AutomatticTracks/src/main/java/com/automattic/android/tracks/crashlogging/CrashLoggingDataProvider.kt
@@ -15,11 +15,6 @@ interface CrashLoggingDataProvider {
     val buildType: String
 
     /**
-     * Provides [CrashLogging] with the name of this release.
-     */
-    val releaseName: String
-
-    /**
      * Provides the [CrashLogging] with information about the user's current locale
      */
     val locale: Locale?

--- a/AutomatticTracks/src/main/java/com/automattic/android/tracks/crashlogging/internal/SentryCrashLogging.kt
+++ b/AutomatticTracks/src/main/java/com/automattic/android/tracks/crashlogging/internal/SentryCrashLogging.kt
@@ -44,7 +44,6 @@ internal class SentryCrashLogging constructor(
             options.apply {
                 dsn = dataProvider.sentryDSN
                 environment = dataProvider.buildType
-                release = dataProvider.releaseName
                 this.tracesSampleRate = tracesSampleRate
                 this.profilesSampleRate = profilesSampleRate
                 isDebug = dataProvider.enableCrashLoggingLogs

--- a/AutomatticTracks/src/test/java/com/automattic/android/tracks/crashlogging/SentryCrashLoggingTest.kt
+++ b/AutomatticTracks/src/test/java/com/automattic/android/tracks/crashlogging/SentryCrashLoggingTest.kt
@@ -80,7 +80,7 @@ class SentryCrashLoggingTest {
             SoftAssertions().apply {
                 assertThat(options.dsn).isEqualTo(dataProvider.sentryDSN)
                 assertThat(options.environment).isEqualTo(dataProvider.buildType)
-                assertThat(options.release).isEqualTo(dataProvider.releaseName)
+                assertThat(options.release).isNull()
             }.assertAll()
         }
     }

--- a/AutomatticTracks/src/test/java/com/automattic/android/tracks/fakes/FakeDataProvider.kt
+++ b/AutomatticTracks/src/test/java/com/automattic/android/tracks/fakes/FakeDataProvider.kt
@@ -13,7 +13,6 @@ import java.util.Locale
 class FakeDataProvider(
     override val sentryDSN: String = BuildConfig.SENTRY_TEST_PROJECT_DSN,
     override val buildType: String = "testBuildType",
-    override val releaseName: String = "testReleaseName",
     override val locale: Locale? = Locale.US,
     override val enableCrashLoggingLogs: Boolean = true,
     var crashLoggingEnabled: Boolean = true,

--- a/sampletracksapp/src/main/java/com/example/sampletracksapp/MainActivity.kt
+++ b/sampletracksapp/src/main/java/com/example/sampletracksapp/MainActivity.kt
@@ -41,7 +41,6 @@ class MainActivity : AppCompatActivity() {
             object : CrashLoggingDataProvider {
                 override val sentryDSN = BuildConfig.SENTRY_TEST_PROJECT_DSN
                 override val buildType = BuildConfig.BUILD_TYPE
-                override val releaseName = "test"
                 override val locale = Locale.US
                 override val enableCrashLoggingLogs = true
                 override val performanceMonitoringConfig = PerformanceMonitoringConfig.Enabled(sampleRate = 1.0, profilesSampleRate = 1.0)


### PR DESCRIPTION
The same change was made to the iOS Tracks library in https://github.com/Automattic/Automattic-Tracks-iOS/pull/267. The gist is we'd want to use the default release name, whose format is `<app-id>@<version>+<build>`.

See pdnsEh-1mT-p2 and p1710798607285959-slack-C6H8C3G23