### PR TITLE
fix: do not track failed http requests

### DIFF
--- a/AutomatticTracks/src/main/java/com/automattic/android/tracks/crashlogging/CrashLoggingOkHttpInterceptorProvider.kt
+++ b/AutomatticTracks/src/main/java/com/automattic/android/tracks/crashlogging/CrashLoggingOkHttpInterceptorProvider.kt
@@ -5,9 +5,9 @@ import okhttp3.Interceptor
 
 object CrashLoggingOkHttpInterceptorProvider {
     fun createInstance(requestFormatter: RequestFormatter): Interceptor =
-        SentryOkHttpInterceptor { span, request, _ ->
+        SentryOkHttpInterceptor(captureFailedRequests = false, beforeSpan = { span, request, _ ->
             span.apply {
                 description = requestFormatter.formatRequestUrl(request)
             }
-        }
+        })
 }


### PR DESCRIPTION
### Description

After bump of Sentry SDK to 7.x version, in WooCommerce Android we started to observe issues with thrown `SentryHttpClientException`. Internal context: p1710951263665769-slack-C6H8C3G23

The reason is that, it seems by a mistake, Sentry SDK in version `7.5.0` enabled `captureFailedRequests` feature by default, while it was disabled by default in previously used by us, `6.32.0`.

I say "by a mistake" because the comment above the code in `7.5.0` states that `captureFailedRequests` should be disabled by default.

#### 6.32.0

https://github.com/getsentry/sentry-java/blob/a57bf6f1cdaf5840c6761c2946723804055a79c3/sentry-android-okhttp/src/main/java/io/sentry/android/okhttp/SentryOkHttpInterceptor.kt#L42

#### 7.5.0

https://github.com/getsentry/sentry-java/blob/c2b79e4ef6bc7a32dc5fd83c980a547b87e5498b/sentry-android-okhttp/src/main/java/io/sentry/android/okhttp/SentryOkHttpInterceptor.kt#L36