### PR TITLE
Allow consumers to delegate release name creation to the SDK

### DIFF
--- a/AutomatticTracks/src/main/java/com/automattic/android/tracks/crashlogging/CrashLoggingDataProvider.kt
+++ b/AutomatticTracks/src/main/java/com/automattic/android/tracks/crashlogging/CrashLoggingDataProvider.kt
@@ -15,6 +15,11 @@ interface CrashLoggingDataProvider {
     val buildType: String
 
     /**
+     * Provides [CrashLogging] with the name of this release.
+     */
+    val releaseName: String
+
+    /**
      * Provides the [CrashLogging] with information about the user's current locale
      */
     val locale: Locale?

--- a/AutomatticTracks/src/main/java/com/automattic/android/tracks/crashlogging/CrashLoggingDataProvider.kt
+++ b/AutomatticTracks/src/main/java/com/automattic/android/tracks/crashlogging/CrashLoggingDataProvider.kt
@@ -17,7 +17,7 @@ interface CrashLoggingDataProvider {
     /**
      * Provides [CrashLogging] with the name of this release.
      */
-    val releaseName: String
+    val releaseName: ReleaseName
 
     /**
      * Provides the [CrashLogging] with information about the user's current locale
@@ -79,6 +79,20 @@ interface CrashLoggingDataProvider {
 }
 
 typealias ExtraKnownKey = String
+
+sealed class ReleaseName {
+    /**
+     * Sets release name attached for every event sent to Sentry. It's indented to use in debug.
+     */
+    class SetByApplication(val name: String) : ReleaseName()
+
+    /**
+     * Delegates setting the release name to the Tracks library. It's indented to use in release
+     * builds. The crash logging framework will single-handledly set the release name based on the
+     * build configuration.
+     */
+    object SetByTracksLibrary : ReleaseName()
+}
 
 sealed class PerformanceMonitoringConfig {
     object Disabled : PerformanceMonitoringConfig()

--- a/AutomatticTracks/src/main/java/com/automattic/android/tracks/crashlogging/CrashLoggingDataProvider.kt
+++ b/AutomatticTracks/src/main/java/com/automattic/android/tracks/crashlogging/CrashLoggingDataProvider.kt
@@ -15,11 +15,6 @@ interface CrashLoggingDataProvider {
     val buildType: String
 
     /**
-     * Provides [CrashLogging] with the name of this release.
-     */
-    val releaseName: String
-
-    /**
      * Provides the [CrashLogging] with information about the user's current locale
      */
     val locale: Locale?

--- a/AutomatticTracks/src/main/java/com/automattic/android/tracks/crashlogging/internal/SentryCrashLogging.kt
+++ b/AutomatticTracks/src/main/java/com/automattic/android/tracks/crashlogging/internal/SentryCrashLogging.kt
@@ -9,6 +9,7 @@ import com.automattic.android.tracks.crashlogging.JsException
 import com.automattic.android.tracks.crashlogging.JsExceptionCallback
 import com.automattic.android.tracks.crashlogging.PerformanceMonitoringConfig.Disabled
 import com.automattic.android.tracks.crashlogging.PerformanceMonitoringConfig.Enabled
+import com.automattic.android.tracks.crashlogging.ReleaseName
 import com.automattic.android.tracks.crashlogging.eventLevel
 import io.sentry.Breadcrumb
 import io.sentry.Sentry
@@ -44,7 +45,10 @@ internal class SentryCrashLogging constructor(
             options.apply {
                 dsn = dataProvider.sentryDSN
                 environment = dataProvider.buildType
-                release = dataProvider.releaseName
+                release = when (val releaseName = dataProvider.releaseName) {
+                    is ReleaseName.SetByApplication -> releaseName.name
+                    ReleaseName.SetByTracksLibrary -> null
+                }
                 this.tracesSampleRate = tracesSampleRate
                 this.profilesSampleRate = profilesSampleRate
                 isDebug = dataProvider.enableCrashLoggingLogs

--- a/AutomatticTracks/src/main/java/com/automattic/android/tracks/crashlogging/internal/SentryCrashLogging.kt
+++ b/AutomatticTracks/src/main/java/com/automattic/android/tracks/crashlogging/internal/SentryCrashLogging.kt
@@ -44,6 +44,7 @@ internal class SentryCrashLogging constructor(
             options.apply {
                 dsn = dataProvider.sentryDSN
                 environment = dataProvider.buildType
+                release = dataProvider.releaseName
                 this.tracesSampleRate = tracesSampleRate
                 this.profilesSampleRate = profilesSampleRate
                 isDebug = dataProvider.enableCrashLoggingLogs

--- a/AutomatticTracks/src/main/java/com/automattic/android/tracks/crashlogging/internal/SentryCrashLogging.kt
+++ b/AutomatticTracks/src/main/java/com/automattic/android/tracks/crashlogging/internal/SentryCrashLogging.kt
@@ -44,7 +44,6 @@ internal class SentryCrashLogging constructor(
             options.apply {
                 dsn = dataProvider.sentryDSN
                 environment = dataProvider.buildType
-                release = dataProvider.releaseName
                 this.tracesSampleRate = tracesSampleRate
                 this.profilesSampleRate = profilesSampleRate
                 isDebug = dataProvider.enableCrashLoggingLogs

--- a/AutomatticTracks/src/test/java/com/automattic/android/tracks/crashlogging/SentryCrashLoggingTest.kt
+++ b/AutomatticTracks/src/test/java/com/automattic/android/tracks/crashlogging/SentryCrashLoggingTest.kt
@@ -80,7 +80,7 @@ class SentryCrashLoggingTest {
             SoftAssertions().apply {
                 assertThat(options.dsn).isEqualTo(dataProvider.sentryDSN)
                 assertThat(options.environment).isEqualTo(dataProvider.buildType)
-                assertThat(options.release).isNull()
+                assertThat(options.release).isEqualTo(dataProvider.releaseName)
             }.assertAll()
         }
     }

--- a/AutomatticTracks/src/test/java/com/automattic/android/tracks/crashlogging/SentryCrashLoggingTest.kt
+++ b/AutomatticTracks/src/test/java/com/automattic/android/tracks/crashlogging/SentryCrashLoggingTest.kt
@@ -80,7 +80,7 @@ class SentryCrashLoggingTest {
             SoftAssertions().apply {
                 assertThat(options.dsn).isEqualTo(dataProvider.sentryDSN)
                 assertThat(options.environment).isEqualTo(dataProvider.buildType)
-                assertThat(options.release).isEqualTo(dataProvider.releaseName)
+                assertThat(options.release).isEqualTo((dataProvider.releaseName as ReleaseName.SetByApplication).name)
             }.assertAll()
         }
     }

--- a/AutomatticTracks/src/test/java/com/automattic/android/tracks/crashlogging/SentryCrashLoggingTest.kt
+++ b/AutomatticTracks/src/test/java/com/automattic/android/tracks/crashlogging/SentryCrashLoggingTest.kt
@@ -80,7 +80,7 @@ class SentryCrashLoggingTest {
             SoftAssertions().apply {
                 assertThat(options.dsn).isEqualTo(dataProvider.sentryDSN)
                 assertThat(options.environment).isEqualTo(dataProvider.buildType)
-                assertThat(options.release).isEqualTo(dataProvider.releaseName)
+                assertThat(options.release).isNull()
             }.assertAll()
         }
     }

--- a/AutomatticTracks/src/test/java/com/automattic/android/tracks/fakes/FakeDataProvider.kt
+++ b/AutomatticTracks/src/test/java/com/automattic/android/tracks/fakes/FakeDataProvider.kt
@@ -13,7 +13,6 @@ import java.util.Locale
 class FakeDataProvider(
     override val sentryDSN: String = BuildConfig.SENTRY_TEST_PROJECT_DSN,
     override val buildType: String = "testBuildType",
-    override val releaseName: String = "testReleaseName",
     override val locale: Locale? = Locale.US,
     override val enableCrashLoggingLogs: Boolean = true,
     var crashLoggingEnabled: Boolean = true,

--- a/AutomatticTracks/src/test/java/com/automattic/android/tracks/fakes/FakeDataProvider.kt
+++ b/AutomatticTracks/src/test/java/com/automattic/android/tracks/fakes/FakeDataProvider.kt
@@ -6,6 +6,7 @@ import com.automattic.android.tracks.crashlogging.CrashLoggingUser
 import com.automattic.android.tracks.crashlogging.EventLevel
 import com.automattic.android.tracks.crashlogging.ExtraKnownKey
 import com.automattic.android.tracks.crashlogging.PerformanceMonitoringConfig
+import com.automattic.android.tracks.crashlogging.ReleaseName
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import java.util.Locale
@@ -13,7 +14,7 @@ import java.util.Locale
 class FakeDataProvider(
     override val sentryDSN: String = BuildConfig.SENTRY_TEST_PROJECT_DSN,
     override val buildType: String = "testBuildType",
-    override val releaseName: String = "testReleaseName",
+    override val releaseName: ReleaseName = ReleaseName.SetByApplication("testReleaseName"),
     override val locale: Locale? = Locale.US,
     override val enableCrashLoggingLogs: Boolean = true,
     var crashLoggingEnabled: Boolean = true,

--- a/AutomatticTracks/src/test/java/com/automattic/android/tracks/fakes/FakeDataProvider.kt
+++ b/AutomatticTracks/src/test/java/com/automattic/android/tracks/fakes/FakeDataProvider.kt
@@ -13,6 +13,7 @@ import java.util.Locale
 class FakeDataProvider(
     override val sentryDSN: String = BuildConfig.SENTRY_TEST_PROJECT_DSN,
     override val buildType: String = "testBuildType",
+    override val releaseName: String = "testReleaseName",
     override val locale: Locale? = Locale.US,
     override val enableCrashLoggingLogs: Boolean = true,
     var crashLoggingEnabled: Boolean = true,

--- a/sampletracksapp/src/main/java/com/example/sampletracksapp/MainActivity.kt
+++ b/sampletracksapp/src/main/java/com/example/sampletracksapp/MainActivity.kt
@@ -13,6 +13,7 @@ import com.automattic.android.tracks.crashlogging.JsException
 import com.automattic.android.tracks.crashlogging.JsExceptionCallback
 import com.automattic.android.tracks.crashlogging.JsExceptionStackTraceElement
 import com.automattic.android.tracks.crashlogging.PerformanceMonitoringConfig
+import com.automattic.android.tracks.crashlogging.ReleaseName
 import com.automattic.android.tracks.crashlogging.RequestFormatter
 import com.automattic.android.tracks.crashlogging.performance.PerformanceMonitoringRepositoryProvider
 import com.automattic.android.tracks.crashlogging.performance.PerformanceTransactionRepository
@@ -41,7 +42,7 @@ class MainActivity : AppCompatActivity() {
             object : CrashLoggingDataProvider {
                 override val sentryDSN = BuildConfig.SENTRY_TEST_PROJECT_DSN
                 override val buildType = BuildConfig.BUILD_TYPE
-                override val releaseName = "test"
+                override val releaseName = ReleaseName.SetByApplication("test")
                 override val locale = Locale.US
                 override val enableCrashLoggingLogs = true
                 override val performanceMonitoringConfig = PerformanceMonitoringConfig.Enabled(sampleRate = 1.0, profilesSampleRate = 1.0)

--- a/sampletracksapp/src/main/java/com/example/sampletracksapp/MainActivity.kt
+++ b/sampletracksapp/src/main/java/com/example/sampletracksapp/MainActivity.kt
@@ -41,7 +41,6 @@ class MainActivity : AppCompatActivity() {
             object : CrashLoggingDataProvider {
                 override val sentryDSN = BuildConfig.SENTRY_TEST_PROJECT_DSN
                 override val buildType = BuildConfig.BUILD_TYPE
-                override val releaseName = "test"
                 override val locale = Locale.US
                 override val enableCrashLoggingLogs = true
                 override val performanceMonitoringConfig = PerformanceMonitoringConfig.Enabled(sampleRate = 1.0, profilesSampleRate = 1.0)

--- a/sampletracksapp/src/main/java/com/example/sampletracksapp/MainActivity.kt
+++ b/sampletracksapp/src/main/java/com/example/sampletracksapp/MainActivity.kt
@@ -41,6 +41,7 @@ class MainActivity : AppCompatActivity() {
             object : CrashLoggingDataProvider {
                 override val sentryDSN = BuildConfig.SENTRY_TEST_PROJECT_DSN
                 override val buildType = BuildConfig.BUILD_TYPE
+                override val releaseName = "test"
                 override val locale = Locale.US
                 override val enableCrashLoggingLogs = true
                 override val performanceMonitoringConfig = PerformanceMonitoringConfig.Enabled(sampleRate = 1.0, profilesSampleRate = 1.0)


### PR DESCRIPTION
Main discussion: #204 

### Description

This PR introduces a possibility for SDK consumers to delegate defining a release name to the Tracks library (eventually - to Sentry SDK).

This is a way to address an issue of incorrectly assigning release names between projects in the same Sentry organization.