### PR TITLE
fix: do not set `null` release if `SetByTracksLibrary` requested

### DIFF
--- a/AutomatticTracks/src/main/java/com/automattic/android/tracks/crashlogging/internal/SentryCrashLogging.kt
+++ b/AutomatticTracks/src/main/java/com/automattic/android/tracks/crashlogging/internal/SentryCrashLogging.kt
@@ -45,9 +45,8 @@ internal class SentryCrashLogging constructor(
             options.apply {
                 dsn = dataProvider.sentryDSN
                 environment = dataProvider.buildType
-                release = when (val releaseName = dataProvider.releaseName) {
-                    is ReleaseName.SetByApplication -> releaseName.name
-                    ReleaseName.SetByTracksLibrary -> null
+                (dataProvider.releaseName as? ReleaseName.SetByApplication)?.let {
+                    release = it.name
                 }
                 this.tracesSampleRate = tracesSampleRate
                 this.profilesSampleRate = profilesSampleRate


### PR DESCRIPTION
### Description

This PR fixes my overlook introduced in #206 . Because `SentryOptions` initialization happens **after** Sentry SDK sets the default `release` name, if we set `null` in case of `SetByTracksLibrary`, we overwrite the value Sentry prepared.

I should've verified it before merge. Sorry for trouble.

### Fix
In the case of `SetByTracksLibrary` simply assign nothing related to releases

### Verification

Using a test project:

#### Before
![image](https://github.com/Automattic/Automattic-Tracks-Android/assets/5845095/2c6d1c55-f653-4cb9-a595-bf0447494c21)

#### After
`null` here is expected
![image](https://github.com/Automattic/Automattic-Tracks-Android/assets/5845095/7ad948c7-8f8f-44fd-aa1d-c431f2101464)

