### PR TITLE
Allow consumers to specify sample rate

### DIFF
--- a/crashlogging/src/main/java/com/automattic/android/tracks/crashlogging/CrashLoggingDataProvider.kt
+++ b/crashlogging/src/main/java/com/automattic/android/tracks/crashlogging/CrashLoggingDataProvider.kt
@@ -42,9 +42,16 @@ interface CrashLoggingDataProvider {
     val user: Flow<CrashLoggingUser?>
 
     /**
-     * Provides the {@link CrashLogging} with information about the current application state.
+     * Provides the [CrashLogging] with information about the current application state.
      */
     val applicationContextProvider: Flow<Map<String, String>>
+
+    /**
+     * Provides [CrashLogging] with information about the sample rate for **error tracking**.
+     * By default, it's 1.0 meaning all errors are reported. Has to be between 0 and 1.
+     */
+    val errorsSampleRate: Double
+        get() = 1.0
 
     /**
      * Provides [CrashLogging] with information about exceptions that should be dropped if is the

--- a/crashlogging/src/main/java/com/automattic/android/tracks/crashlogging/CrashLoggingDataProvider.kt
+++ b/crashlogging/src/main/java/com/automattic/android/tracks/crashlogging/CrashLoggingDataProvider.kt
@@ -47,11 +47,11 @@ interface CrashLoggingDataProvider {
     val applicationContextProvider: Flow<Map<String, String>>
 
     /**
-     * Provides [CrashLogging] with information about the sample rate for **error tracking**.
-     * By default, it's 1.0 meaning all errors are reported. Has to be between 0 and 1.
+     * Provides [CrashLogging] with information about the sampling for **error tracking**.
+     * By default, sampling is disabled meaning all errors are reported.
      */
-    val errorsSampleRate: Double
-        get() = 1.0
+    val errorSampling: ErrorSampling
+        get() = ErrorSampling.Disabled
 
     /**
      * Provides [CrashLogging] with information about exceptions that should be dropped if is the
@@ -121,6 +121,22 @@ sealed class PerformanceMonitoringConfig {
         init {
             assert(sampleRate in 0.0..1.0)
             assert(profilesSampleRate in 0.0..1.0)
+        }
+    }
+}
+
+sealed class ErrorSampling {
+    object Disabled : ErrorSampling()
+
+    data class Enabled(
+        /**
+         * Provides sample rate for error tracking. Indicates how often do we report errors.
+         * Has to be between 0 and 1.
+         */
+        val sampleRate: Double
+    ) : ErrorSampling() {
+        init {
+            assert(sampleRate in 0.0..1.0)
         }
     }
 }

--- a/crashlogging/src/main/java/com/automattic/android/tracks/crashlogging/internal/SentryCrashLogging.kt
+++ b/crashlogging/src/main/java/com/automattic/android/tracks/crashlogging/internal/SentryCrashLogging.kt
@@ -75,6 +75,7 @@ internal class SentryCrashLogging constructor(
                     appendExtra(event)
                     event
                 }
+                sampleRate = dataProvider.errorsSampleRate
             }
         }
 

--- a/crashlogging/src/main/java/com/automattic/android/tracks/crashlogging/internal/SentryCrashLogging.kt
+++ b/crashlogging/src/main/java/com/automattic/android/tracks/crashlogging/internal/SentryCrashLogging.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import com.automattic.android.tracks.crashlogging.CrashLogging
 import com.automattic.android.tracks.crashlogging.CrashLoggingDataProvider
 import com.automattic.android.tracks.crashlogging.CrashLoggingUser
+import com.automattic.android.tracks.crashlogging.ErrorSampling
 import com.automattic.android.tracks.crashlogging.ExtraKnownKey
 import com.automattic.android.tracks.crashlogging.JsException
 import com.automattic.android.tracks.crashlogging.JsExceptionCallback
@@ -75,7 +76,10 @@ internal class SentryCrashLogging constructor(
                     appendExtra(event)
                     event
                 }
-                sampleRate = dataProvider.errorsSampleRate
+                sampleRate = when (val errorsSampleRate = dataProvider.errorSampling) {
+                    ErrorSampling.Disabled -> null
+                    is ErrorSampling.Enabled -> errorsSampleRate.sampleRate
+                }
             }
         }
 

--- a/crashlogging/src/test/java/com/automattic/android/tracks/crashlogging/SentryCrashLoggingTest.kt
+++ b/crashlogging/src/test/java/com/automattic/android/tracks/crashlogging/SentryCrashLoggingTest.kt
@@ -56,7 +56,8 @@ class SentryCrashLoggingTest {
         shouldDropException: (String, String, String) -> Boolean = dataProvider.shouldDropException,
         extraKeys: List<String> = dataProvider.extraKeys,
         provideExtrasForEvent: (Map<ExtraKnownKey, String>) -> Map<ExtraKnownKey, String> = dataProvider.provideExtrasForEvent,
-        applicationContext: Map<String, String> = dataProvider.fakeApplicationContextEmitter.value
+        applicationContext: Map<String, String> = dataProvider.fakeApplicationContextEmitter.value,
+        errorSampling: ErrorSampling = dataProvider.errorSampling
     ) {
         dataProvider = FakeDataProvider(
             locale = locale,
@@ -65,7 +66,8 @@ class SentryCrashLoggingTest {
             shouldDropException = shouldDropException,
             extraKeys = extraKeys,
             provideExtrasForEvent = provideExtrasForEvent,
-            initialApplicationContext = applicationContext
+            initialApplicationContext = applicationContext,
+            errorSampling = errorSampling
         )
 
         crashLogging = SentryCrashLogging(
@@ -400,6 +402,23 @@ class SentryCrashLoggingTest {
                     .doesNotThrowAnyException()
             }
         }.assertAll()
+    }
+
+    @Test
+    fun `should provide null sampling rate if error sampling is disabled`() {
+        dataProvider.errorSampling = ErrorSampling.Disabled
+        prepareSut()
+
+        assertThat(capturedOptions.sampleRate).isNull()
+    }
+
+    @Test
+    fun `should provide expected sampling rate if error sampling is enabled`() {
+        val errorSamplingRate = 0.3
+        dataProvider.errorSampling = ErrorSampling.Enabled(errorSamplingRate)
+        prepareSut()
+
+        assertThat(capturedOptions.sampleRate).isEqualTo(errorSamplingRate)
     }
 
     private val crashLoggingMethods = listOf(

--- a/crashlogging/src/test/java/com/automattic/android/tracks/fakes/FakeDataProvider.kt
+++ b/crashlogging/src/test/java/com/automattic/android/tracks/fakes/FakeDataProvider.kt
@@ -3,6 +3,7 @@ package com.automattic.android.tracks.fakes
 import com.automattic.android.tracks.crashlogging.BuildConfig
 import com.automattic.android.tracks.crashlogging.CrashLoggingDataProvider
 import com.automattic.android.tracks.crashlogging.CrashLoggingUser
+import com.automattic.android.tracks.crashlogging.ErrorSampling
 import com.automattic.android.tracks.crashlogging.EventLevel
 import com.automattic.android.tracks.crashlogging.ExtraKnownKey
 import com.automattic.android.tracks.crashlogging.PerformanceMonitoringConfig
@@ -21,6 +22,7 @@ class FakeDataProvider(
     var shouldDropException: (String, String, String) -> Boolean = { _: String, _: String, _: String -> false },
     var extraKeys: List<String> = emptyList(),
     var provideExtrasForEvent: (Map<ExtraKnownKey, String>) -> Map<ExtraKnownKey, String> = { currentExtras -> currentExtras },
+    override var errorSampling: ErrorSampling = ErrorSampling.Disabled,
     initialUser: CrashLoggingUser? = testUser1,
     initialApplicationContext: Map<String, String> = emptyMap()
 ) : CrashLoggingDataProvider {


### PR DESCRIPTION
### Description

This PR introduces a new property to configure for consumers: `errorSampling` which allows them to reduce the number of issues they report.

### Testing
It's not necessarily - the property is passed (unit tests) and we don't aim to test Sentry framework here - we trust it simply works.