### PR TITLE
Make user details nullable and null by default

### DIFF
--- a/crashlogging/src/main/java/com/automattic/android/tracks/crashlogging/CrashLoggingUser.kt
+++ b/crashlogging/src/main/java/com/automattic/android/tracks/crashlogging/CrashLoggingUser.kt
@@ -1,7 +1,7 @@
 package com.automattic.android.tracks.crashlogging
 
 data class CrashLoggingUser(
-    val userID: String,
-    val email: String,
-    val username: String
+    val userID: String? = null,
+    val email: String? = null,
+    val username: String? = null
 )


### PR DESCRIPTION
### Description

Some projects, e.g. Pocket Casts, doesn't have user id or username. We shouldn't force those values - empty strings will be just a noise