### PR TITLE
Track SDK version code

### DIFF
--- a/AutomatticTracks/src/main/java/com/automattic/android/tracks/DeviceInformation.java
+++ b/AutomatticTracks/src/main/java/com/automattic/android/tracks/DeviceInformation.java
@@ -68,6 +68,7 @@ import java.util.Locale;
 
         final String mOs = "Android";
         final String mOSVersion = Build.VERSION.RELEASE == null ? "UNKNOWN" : Build.VERSION.RELEASE;
+        final int mOsSdkVersion = Build.VERSION.SDK_INT;
         final String mManufacturer = Build.MANUFACTURER == null ? "UNKNOWN" : Build.MANUFACTURER;
         final String mBrand = Build.BRAND == null ? "UNKNOWN" : Build.BRAND;
         final String mModel = Build.MODEL == null ? "UNKNOWN" : Build.MODEL;
@@ -149,6 +150,7 @@ import java.util.Locale;
         try {
             mImmutableDeviceInfoJSON.put("os", mOs);
             mImmutableDeviceInfoJSON.put("os_version", mOSVersion);
+            mImmutableDeviceInfoJSON.put("os_sdk_version", mOsSdkVersion);
             mImmutableDeviceInfoJSON.put("manufacturer", mManufacturer);
             mImmutableDeviceInfoJSON.put("brand", mBrand);
             mImmutableDeviceInfoJSON.put("model", mModel);

--- a/AutomatticTracks/src/main/java/com/automattic/android/tracks/DeviceInformation.java
+++ b/AutomatticTracks/src/main/java/com/automattic/android/tracks/DeviceInformation.java
@@ -67,7 +67,7 @@ import java.util.Locale;
         mContext = context;
 
         final String mOs = "Android";
-        final String mOSVersion = Build.VERSION.RELEASE == null ? "UNKNOWN" : Build.VERSION.RELEASE;
+        final String mOsVersion = Build.VERSION.RELEASE == null ? "UNKNOWN" : Build.VERSION.RELEASE;
         final int mOsSdkVersion = Build.VERSION.SDK_INT;
         final String mManufacturer = Build.MANUFACTURER == null ? "UNKNOWN" : Build.MANUFACTURER;
         final String mBrand = Build.BRAND == null ? "UNKNOWN" : Build.BRAND;
@@ -149,7 +149,7 @@ import java.util.Locale;
         mImmutableDeviceInfoJSON = new JSONObject();
         try {
             mImmutableDeviceInfoJSON.put("os", mOs);
-            mImmutableDeviceInfoJSON.put("os_version", mOSVersion);
+            mImmutableDeviceInfoJSON.put("os_version", mOsVersion);
             mImmutableDeviceInfoJSON.put("os_sdk_version", mOsSdkVersion);
             mImmutableDeviceInfoJSON.put("manufacturer", mManufacturer);
             mImmutableDeviceInfoJSON.put("brand", mBrand);


### PR DESCRIPTION
`Build.VERSION.RELEASE` is not very developer-friendly. It can contain things like `8.0.0`, `8.1.0`, `8.1Go`, `12.0`, and so on. It is not normalized and it is not super useful when trying to cross-reference things with the documentation.

This PR ads `SDK_INT` which corresponds to API level of Android installed on a device.