### PR TITLE
Move Sentry config to CrashLogging manifest

### DIFF
--- a/AutomatticTracks/src/main/AndroidManifest.xml
+++ b/AutomatticTracks/src/main/AndroidManifest.xml
@@ -3,12 +3,4 @@
 
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.BLUETOOTH" />
-
-    <application>
-        <meta-data
-            android:name="io.sentry.auto-init"
-            android:value="false" />
-
-        <meta-data android:name="io.sentry.breadcrumbs.user-interaction" android:value="false" />
-    </application>
 </manifest>

--- a/crashlogging/src/main/AndroidManifest.xml
+++ b/crashlogging/src/main/AndroidManifest.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <application>
+        <meta-data
+            android:name="io.sentry.auto-init"
+            android:value="false" />
+
+        <meta-data android:name="io.sentry.breadcrumbs.user-interaction" android:value="false" />
+    </application>
+</manifest>


### PR DESCRIPTION
This PR moves Sentry's configuration declared in `AndroidManifest.xml` from `tracks` to `crashlogging`.

This way, if a project uses only `crashlogging` module, they will have the correct Sentry setup.

It's a follow-up to #212 