### PR TITLE
Fix all Simplenote users and Pocket Cast users being set to Day One users

### DIFF
--- a/AutomatticTracks/src/main/java/com/automattic/android/tracks/MessageBuilder.java
+++ b/AutomatticTracks/src/main/java/com/automattic/android/tracks/MessageBuilder.java
@@ -107,9 +107,11 @@ class MessageBuilder {
                 case SIMPLENOTE:
                     eventJSON.put(USER_LOGIN_NAME_KEY, event.getUser());
                     eventJSON.put(USER_TYPE_KEY, USER_TYPE_SIMPLENOTE);
+                    break;
                 case POCKETCASTS:
                     eventJSON.put(USER_ID_KEY, event.getUser());
                     eventJSON.put(USER_TYPE_KEY, USER_TYPE_POCKETCASTS);
+                    break;
                 case DAYONE:
                     eventJSON.put(USER_ID_KEY, event.getUser());
                     eventJSON.put(USER_TYPE_KEY, USER_TYPE_DAYONE);


### PR DESCRIPTION
Switch on user type used fall-through for Simplenote and Pocket Casts users, which marked them as Day One ones.