### PR TITLE
[Dependency Analysis] Add Android Gradle Plugin

### DIFF
--- a/.buildkite/schedules/dependency-analysis.yml
+++ b/.buildkite/schedules/dependency-analysis.yml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
+---
+
+common_params:
+  # Common plugin settings to use with the `plugins` key.
+  - &common_plugins
+    - automattic/a8c-ci-toolkit#2.15.0
+
+agents:
+  queue: android
+
+steps:
+  - label: "dependency analysis"
+    command: |
+      echo "--- 📊 Analyzing"
+      cp gradle.properties-example gradle.properties
+      ./gradlew buildHealth
+    plugins: *common_plugins
+    artifact_paths:
+      - "build/reports/dependency-analysis/build-health-report.*"
+    notify:
+      - slack: "#android-core-notifs"
+        if: build.state == "failed"

--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 plugins {
     id 'com.android.library' apply false
     id 'org.jetbrains.kotlin.android' apply false
+    id "com.autonomousapps.dependency-analysis"
 }
 
 allprojects {

--- a/gradle.properties-example
+++ b/gradle.properties-example
@@ -1,3 +1,6 @@
 org.gradle.jvmargs=-Xmx6g
 android.useAndroidX=true
 sentryTestProjectDSN="https://public@sentry.example.com/1"
+
+# Dependency Analysis Plugin
+dependency.analysis.android.ignored.variants=release

--- a/settings.gradle
+++ b/settings.gradle
@@ -2,6 +2,7 @@ pluginManagement {
     gradle.ext.kotlinVersion = '1.9.24'
     gradle.ext.agpVersion = '8.1.0'
     gradle.ext.automatticPublishToS3Version = '0.8.0'
+    gradle.ext.dependencyAnalysisVersion = '1.28.0'
 
     plugins {
         id 'com.android.library' version gradle.ext.agpVersion
@@ -9,6 +10,7 @@ pluginManagement {
         id 'org.jetbrains.kotlin.android' version gradle.ext.kotlinVersion
         id 'com.automattic.android.publish-to-s3' version gradle.ext.automatticPublishToS3Version
         id 'androidx.benchmark' version '1.2.4'
+        id "com.autonomousapps.dependency-analysis" version gradle.ext.dependencyAnalysisVersion
     }
     repositories {
         maven {


### PR DESCRIPTION
Project Thread: paaHJt-6yU-p2
Required By: [BuildkiteCI#482](https://github.com/Automattic/buildkite-ci/pull/482)
Depends On:
- [x] #227

This PR adds the dependency analysis Android Gradle plugin to this project, for dependency analysis purposes.

### Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

For now, only the main `buildHealth` task is going to be utilized and produce data once every week on CI (see this [commit](https://github.com/Automattic/Automattic-Tracks-Android/commit/74620ed7cd26a6f910ab786fd4088be32b27a55e) and [this](https://github.com/Automattic/buildkite-ci/pull/482) PR). Amongst other, this data will include the following:

- Number of modules (`projectCount`)
- Unused dependencies which should be removed (`unusedCount`)
- Transitive dependencies which should be declared directly (`undeclaredCount`)
- Existing dependencies which should be modified to be as indicated (`misDeclaredCount`)
- Dependencies which could be compile-only (`compileOnlyCount`)
- Dependencies which should be removed or changed to runtime-only (`runtimeOnlyCount`)

Afterward, this data will get collected from CI and uploaded to our Apps Metrics infrastructure, for visualization and alerting purposes.

### Testing Steps

1. Local: Run the `./gradlew buildHealth` task and verify that under the root level `build/reports/dependency-analysis` folder you get the below 2 reports both, in JSON and text format:
    - `build-health-report.json`
    - `build-health-report.txt`
2. CI: Using the `New Build` 🟢 CI button for [TracksAndroid](https://buildkite.com/automattic/automattic-tracks-android), test this standalone dependency analysis job (see form below). Then:
    - When CI starts, make sure that adding `/meta-data` to that CI build's URL ([example](https://buildkite.com/automattic/automattic-tracks-android/builds/290/meta-data)) will give you one extra meta-data, the `pipeline_file` one, with a value of `schedules/dependency-analysis.yml` (see screenshot below):
    - When CI completes, make sure that the below 2 CI artifacts are available both, in JSON and text format:
        - `build/reports/dependency-analysis/build-health-report.json`
        - `build/reports/dependency-analysis/build-health-report.txt`
3. REST: Using the Buildkite's REST API you could query for this type of builds, using the [meta-data](https://buildkite.com/docs/apis/rest-api/builds#list-all-builds) query parameter, and see that the result is the expect one. Use this query: `https://api.buildkite.com/v2/organizations/automattic/pipelines/automattic-tracks-android/builds?meta_data[pipeline_file]=schedules/dependency-analysis.yml`

![image](https://github.com/Automattic/Automattic-Tracks-Android/assets/9729923/a8908a84-8807-4f6c-9644-dc1bdf2c99f7)

![image](https://github.com/Automattic/Automattic-Tracks-Android/assets/9729923/97a49e63-4869-4510-a189-55d70ac827bd)