### PR TITLE
[Dependency Analysis] Remove Unused Dependencies

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -18,7 +18,7 @@ steps:
     plugins: [$CI_TOOLKIT]
     command: |
       cp gradle.properties-example gradle.properties
-      ./gradlew lintRelease ciktlint
+      ./gradlew lint ciktlint
     artifact_paths:
       - "**/build/reports/lint-results.*"
       - "**/build/ktlint.xml"

--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ proguard/
 
 # private config file
 gradle.properties
+!/benchmark/gradle.properties
 
 # OS X generated file
 .DS_Store

--- a/AutomatticTracks/build.gradle
+++ b/AutomatticTracks/build.gradle
@@ -17,7 +17,6 @@ repositories {
 
 dependencies {
     implementation "androidx.annotation:annotation:$androidxAnnotationVersion"
-    implementation "com.squareup.okhttp3:okhttp:$squareupOkhttpVersion"
 
     lintChecks "org.wordpress:lint:$wordpressLintVersion"
 }

--- a/benchmark/build.gradle.kts
+++ b/benchmark/build.gradle.kts
@@ -43,6 +43,11 @@ android {
             isDefault = true
         }
     }
+
+    lint {
+        warningsAsErrors = true
+        lintConfig = file("${project.rootDir}/config/lint/lint.xml")
+    }
 }
 
 dependencies {

--- a/benchmark/build.gradle.kts
+++ b/benchmark/build.gradle.kts
@@ -57,3 +57,12 @@ dependencies {
     // https://developer.android.com/studio/projects/android-library#Convert
     androidTestImplementation(project(":AutomatticTracks"))
 }
+
+dependencyAnalysis {
+    issues {
+        onUnusedDependencies {
+            // This dependency is not needed but kept to preserve the module's default configuration.
+            exclude("org.jetbrains.kotlin:kotlin-stdlib")
+        }
+    }
+}

--- a/benchmark/build.gradle.kts
+++ b/benchmark/build.gradle.kts
@@ -62,12 +62,3 @@ dependencies {
     // https://developer.android.com/studio/projects/android-library#Convert
     androidTestImplementation(project(":AutomatticTracks"))
 }
-
-dependencyAnalysis {
-    issues {
-        onUnusedDependencies {
-            // This dependency is not needed but kept to preserve the module's default configuration.
-            exclude("org.jetbrains.kotlin:kotlin-stdlib")
-        }
-    }
-}

--- a/benchmark/gradle.properties
+++ b/benchmark/gradle.properties
@@ -1,0 +1,1 @@
+kotlin.stdlib.default.dependency=false

--- a/benchmark/src/main/AndroidManifest.xml
+++ b/benchmark/src/main/AndroidManifest.xml
@@ -1,14 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.BLUETOOTH" />
 
     <application android:usesCleartextTraffic="true">
+        <!--suppress AndroidDomInspection -->
         <activity
             android:name=".TrackingMethodsBenchmark$SampleActivity"
-            android:exported="true">
+            android:exported="true"
+            tools:ignore="MissingClass">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,6 @@ ext {
     // main
     androidxAnnotationVersion = "1.1.0"
     androidxAppcompatVersion = '1.2.0'
-    androidxCoreVersion = '1.3.2'
     googleMaterialVersion = '1.3.0'
     kotlinxCoroutinesVersion = '1.6.4'
     kotlinxCoroutinesExperimentationVersion = '1.4.2' // TODO: Align 'kotlinx coroutines' versions.

--- a/crashlogging/build.gradle
+++ b/crashlogging/build.gradle
@@ -11,7 +11,7 @@ repositories {
 
 dependencies {
     implementation platform("io.sentry:sentry-bom:$sentryBomVersion")
-    implementation "io.sentry:sentry-android"
+    implementation "io.sentry:sentry-android-core"
     implementation "io.sentry:sentry-okhttp"
     implementation "io.sentry:sentry-android-fragment"
     implementation "io.sentry:sentry-compose-android"

--- a/crashlogging/build.gradle
+++ b/crashlogging/build.gradle
@@ -45,6 +45,7 @@ android {
     lint {
         warningsAsErrors true
         lintConfig file("${project.rootDir}/config/lint/lint.xml")
+        disable 'ObsoleteLintCustomCheck'
     }
 }
 

--- a/crashlogging/build.gradle
+++ b/crashlogging/build.gradle
@@ -42,6 +42,10 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
+    lint {
+        warningsAsErrors true
+        lintConfig file("${project.rootDir}/config/lint/lint.xml")
+    }
 }
 
 afterEvaluate {

--- a/crashlogging/build.gradle
+++ b/crashlogging/build.gradle
@@ -12,7 +12,7 @@ repositories {
 dependencies {
     implementation platform("io.sentry:sentry-bom:$sentryBomVersion")
     implementation "io.sentry:sentry-android"
-    implementation "io.sentry:sentry-android-okhttp"
+    implementation "io.sentry:sentry-okhttp"
     implementation "io.sentry:sentry-android-fragment"
     implementation "io.sentry:sentry-compose-android"
     implementation "androidx.annotation:annotation:$androidxAnnotationVersion"

--- a/sampletracksapp/build.gradle
+++ b/sampletracksapp/build.gradle
@@ -48,3 +48,12 @@ dependencies {
     // For performance showcase
     implementation "com.squareup.okhttp3:okhttp:$squareupOkhttpVersion"
 }
+
+dependencyAnalysis {
+    issues {
+        onUnusedDependencies {
+            // This dependency is not needed but it is kept to preserve the module's default configuration.
+            exclude(":AutomatticTracks")
+        }
+    }
+}

--- a/sampletracksapp/build.gradle
+++ b/sampletracksapp/build.gradle
@@ -41,7 +41,6 @@ android {
 dependencies {
     implementation project(":AutomatticTracks")
     implementation project(":crashlogging")
-    implementation "androidx.core:core-ktx:$androidxCoreVersion"
     implementation "androidx.appcompat:appcompat:$androidxAppcompatVersion"
     implementation "com.google.android.material:material:$googleMaterialVersion"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlinxCoroutinesVersion"

--- a/settings.gradle
+++ b/settings.gradle
@@ -2,7 +2,7 @@ pluginManagement {
     gradle.ext.kotlinVersion = '1.9.24'
     gradle.ext.agpVersion = '8.1.0'
     gradle.ext.automatticPublishToS3Version = '0.8.0'
-    gradle.ext.dependencyAnalysisVersion = '1.28.0'
+    gradle.ext.dependencyAnalysisVersion = '1.33.0'
 
     plugins {
         id 'com.android.library' version gradle.ext.agpVersion


### PR DESCRIPTION
Project Thread: paaHJt-6YV-p2

### Description

Based on the `unused` related advises generated by the [Dependency Analysis](https://github.com/autonomousapps/dependency-analysis-gradle-plugin) Gradle plugin, this PR removes all unused dependencies from this project.

FYI: As part of this change, the [Dependency Analysis](https://github.com/autonomousapps/dependency-analysis-gradle-plugin) Gradle plugin got also updated to its latest [1.33.0](https://github.com/autonomousapps/dependency-analysis-gradle-plugin/blob/main/CHANGELOG.md#version-1330) version.

### Testing Steps

1. Tooling:
    - Run the `./gradlew buildHealth` task and verify that there is no `unused` related advise remaining within both reports, JSON and txt included:
        - `build-health-report.json` -> Search for `unusedCount`
        - `build-health-report.txt` -> Search for `unused`
    - Check the manually triggered [scheduled build](https://buildkite.com/automattic/automattic-tracks-android/builds/317) and verify that everything works as expected with this newer version of the [Dependency Analysis](https://github.com/autonomousapps/dependency-analysis-gradle-plugin) Gradle plugin ([1.33.0](https://github.com/autonomousapps/dependency-analysis-gradle-plugin/blob/main/CHANGELOG.md#version-1330)).
3. Testing:
    - Smoke test the sample tracks app, try out all available screens and functionality. Verify everything is working as expected.
    - Also, if you want to be thorough about reviewing the changes, you could quickly smoke test, either the [JP/WPAndroid](https://github.com/wordpress-mobile/WordPress-Android) and/or [WCAndroid](https://github.com/woocommerce/woocommerce-android), with this version of `Tracks`, or via composite builds, and see if it works as expected.