### PR TITLE
Introduce `ExperimentRestClient` and basic domain models

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,7 +49,6 @@ ext {
     androidxCoreVersion = '1.3.2'
     googleMaterialVersion = '1.3.0'
     kotlinxCoroutinesVersion = '1.6.4'
-    kotlinxCoroutinesExperimentationVersion = '1.4.2' // TODO: Align 'kotlinx coroutines' versions.
     sentryBomVersion = '7.14.0'
     squareupOkhttpVersion = '4.9.0'
 

--- a/experimentation/build.gradle
+++ b/experimentation/build.gradle
@@ -45,7 +45,7 @@ dependencies {
     ksp "com.squareup.moshi:moshi-kotlin-codegen:$moshi"
 
     // Coroutines
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlinxCoroutinesExperimentationVersion"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlinxCoroutinesVersion"
 
     //FluxC
     implementation "org.wordpress:fluxc:$wordPressFluxCVersion"
@@ -53,13 +53,14 @@ dependencies {
     //WordPress utils
     implementation "org.wordpress:utils:$wordPressUtilsVersion"
 
-    testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$kotlinxCoroutinesExperimentationVersion"
+    testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$kotlinxCoroutinesVersion"
     testImplementation "junit:junit:$junitVersion"
     testImplementation "org.assertj:assertj-core:$assertjVersion"
     testImplementation "org.mockito.kotlin:mockito-kotlin:$mockitoKotlinVersion"
     testImplementation "org.mockito:mockito-inline:$mockitoInlineVersion"
 
     testImplementation "com.squareup.okhttp3:mockwebserver:$okHttp"
+    testImplementation "org.jetbrains.kotlin:kotlin-test:${gradle.ext.kotlinVersion}"
 }
 
 afterEvaluate {

--- a/experimentation/build.gradle
+++ b/experimentation/build.gradle
@@ -62,6 +62,15 @@ dependencies {
     testImplementation "com.squareup.okhttp3:mockwebserver:$okHttp"
 }
 
+dependencyAnalysis {
+    issues {
+        onUsedTransitiveDependencies {
+            // It doesn't seem necessary to directly declare this
+            exclude("com.squareup.okio:okio")
+        }
+    }
+}
+
 afterEvaluate {
     publishing {
         publications {

--- a/experimentation/build.gradle
+++ b/experimentation/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id "com.android.library"
     id "org.jetbrains.kotlin.android"
     id 'com.automattic.android.publish-to-s3'
-    id "com.google.devtools.ksp" version "1.9.24-1.0.20"
+    id "com.google.devtools.ksp"
 }
 
 repositories {

--- a/experimentation/build.gradle
+++ b/experimentation/build.gradle
@@ -60,7 +60,6 @@ dependencies {
     testImplementation "org.mockito:mockito-inline:$mockitoInlineVersion"
 
     testImplementation "com.squareup.okhttp3:mockwebserver:$okHttp"
-    testImplementation "org.jetbrains.kotlin:kotlin-test:${gradle.ext.kotlinVersion}"
 }
 
 afterEvaluate {

--- a/experimentation/build.gradle
+++ b/experimentation/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id "com.android.library"
     id "org.jetbrains.kotlin.android"
     id 'com.automattic.android.publish-to-s3'
+    id "com.google.devtools.ksp" version "1.9.24-1.0.20"
 }
 
 repositories {
@@ -36,6 +37,13 @@ android {
 }
 
 dependencies {
+    def okHttp = "4.12.0"
+    implementation "com.squareup.okhttp3:okhttp:$okHttp"
+
+    def moshi = "1.15.1"
+    implementation "com.squareup.moshi:moshi:$moshi"
+    ksp "com.squareup.moshi:moshi-kotlin-codegen:$moshi"
+
     // Coroutines
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlinxCoroutinesExperimentationVersion"
 
@@ -50,6 +58,8 @@ dependencies {
     testImplementation "org.assertj:assertj-core:$assertjVersion"
     testImplementation "org.mockito.kotlin:mockito-kotlin:$mockitoKotlinVersion"
     testImplementation "org.mockito:mockito-inline:$mockitoInlineVersion"
+
+    testImplementation "com.squareup.okhttp3:mockwebserver:$okHttp"
 }
 
 afterEvaluate {

--- a/experimentation/src/main/java/com/automattic/android/experimentation/domain/Assignments.kt
+++ b/experimentation/src/main/java/com/automattic/android/experimentation/domain/Assignments.kt
@@ -1,6 +1,6 @@
 package com.automattic.android.experimentation.domain
 
-class Assignments(
+data class Assignments(
     val variations: Map<String, Variation>,
     val ttl: Int,
     val fetchedAt: Long

--- a/experimentation/src/main/java/com/automattic/android/experimentation/domain/Assignments.kt
+++ b/experimentation/src/main/java/com/automattic/android/experimentation/domain/Assignments.kt
@@ -3,5 +3,5 @@ package com.automattic.android.experimentation.domain
 data class Assignments(
     val variations: Map<String, Variation>,
     val ttl: Int,
-    val fetchedAt: Long
+    val fetchedAt: Long,
 )

--- a/experimentation/src/main/java/com/automattic/android/experimentation/domain/Assignments.kt
+++ b/experimentation/src/main/java/com/automattic/android/experimentation/domain/Assignments.kt
@@ -1,0 +1,7 @@
+package com.automattic.android.experimentation.domain
+
+class Assignments(
+    val variations: Map<String, Variation>,
+    val ttl: Int,
+    val fetchedAt: Long
+)

--- a/experimentation/src/main/java/com/automattic/android/experimentation/domain/Clock.kt
+++ b/experimentation/src/main/java/com/automattic/android/experimentation/domain/Clock.kt
@@ -1,0 +1,9 @@
+package com.automattic.android.experimentation.domain
+
+internal fun interface Clock {
+    fun currentTimeMillis(): Long
+}
+
+internal class SystemClock : Clock {
+    override fun currentTimeMillis(): Long = System.currentTimeMillis()
+}

--- a/experimentation/src/main/java/com/automattic/android/experimentation/domain/Variation.kt
+++ b/experimentation/src/main/java/com/automattic/android/experimentation/domain/Variation.kt
@@ -1,6 +1,6 @@
 package com.automattic.android.experimentation.domain
 
-sealed class Variation{
+sealed class Variation {
     data class Treatment(val name: String) : Variation()
     data object Control : Variation()
 }

--- a/experimentation/src/main/java/com/automattic/android/experimentation/domain/Variation.kt
+++ b/experimentation/src/main/java/com/automattic/android/experimentation/domain/Variation.kt
@@ -1,0 +1,6 @@
+package com.automattic.android.experimentation.domain
+
+sealed class Variation{
+    class Treatment(val name: String) : Variation()
+    object Control : Variation()
+}

--- a/experimentation/src/main/java/com/automattic/android/experimentation/domain/Variation.kt
+++ b/experimentation/src/main/java/com/automattic/android/experimentation/domain/Variation.kt
@@ -1,6 +1,6 @@
 package com.automattic.android.experimentation.domain
 
 sealed class Variation{
-    class Treatment(val name: String) : Variation()
-    object Control : Variation()
+    data class Treatment(val name: String) : Variation()
+    data object Control : Variation()
 }

--- a/experimentation/src/main/java/com/automattic/android/experimentation/remote/AssignmentsDto.kt
+++ b/experimentation/src/main/java/com/automattic/android/experimentation/remote/AssignmentsDto.kt
@@ -1,0 +1,12 @@
+package com.automattic.android.experimentation.remote
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+internal data class AssignmentsDto(
+    @Json(name = "variations")
+    val variations: Map<String, String?>,
+    @Json(name = "ttl")
+    val ttl: Int
+)

--- a/experimentation/src/main/java/com/automattic/android/experimentation/remote/AssignmentsDto.kt
+++ b/experimentation/src/main/java/com/automattic/android/experimentation/remote/AssignmentsDto.kt
@@ -8,5 +8,5 @@ internal data class AssignmentsDto(
     @Json(name = "variations")
     val variations: Map<String, String?>,
     @Json(name = "ttl")
-    val ttl: Int
+    val ttl: Int,
 )

--- a/experimentation/src/main/java/com/automattic/android/experimentation/remote/AssignmentsDtoMapper.kt
+++ b/experimentation/src/main/java/com/automattic/android/experimentation/remote/AssignmentsDtoMapper.kt
@@ -1,0 +1,20 @@
+package com.automattic.android.experimentation.remote
+
+import com.automattic.android.experimentation.domain.Assignments
+import com.automattic.android.experimentation.domain.Variation
+
+internal object AssignmentsDtoMapper {
+    fun AssignmentsDto.toAssignments(fetchedAt: Long): Assignments {
+        return Assignments(
+            variations = variations.mapValues { (key, value) ->
+                if (value == null || value == "control") {
+                    Variation.Control
+                } else {
+                    Variation.Treatment(value)
+                }
+            },
+            ttl = ttl,
+            fetchedAt = fetchedAt
+        )
+    }
+}

--- a/experimentation/src/main/java/com/automattic/android/experimentation/remote/AssignmentsDtoMapper.kt
+++ b/experimentation/src/main/java/com/automattic/android/experimentation/remote/AssignmentsDtoMapper.kt
@@ -6,7 +6,7 @@ import com.automattic.android.experimentation.domain.Variation
 internal object AssignmentsDtoMapper {
     fun AssignmentsDto.toAssignments(fetchedAt: Long): Assignments {
         return Assignments(
-            variations = variations.mapValues { (key, value) ->
+            variations = variations.mapValues { (_, value) ->
                 if (value == null || value == "control") {
                     Variation.Control
                 } else {

--- a/experimentation/src/main/java/com/automattic/android/experimentation/remote/AssignmentsDtoMapper.kt
+++ b/experimentation/src/main/java/com/automattic/android/experimentation/remote/AssignmentsDtoMapper.kt
@@ -14,7 +14,7 @@ internal object AssignmentsDtoMapper {
                 }
             },
             ttl = ttl,
-            fetchedAt = fetchedAt
+            fetchedAt = fetchedAt,
         )
     }
 }

--- a/experimentation/src/main/java/com/automattic/android/experimentation/remote/ExperimentRestClient.kt
+++ b/experimentation/src/main/java/com/automattic/android/experimentation/remote/ExperimentRestClient.kt
@@ -5,6 +5,7 @@ import com.automattic.android.experimentation.domain.Clock
 import com.automattic.android.experimentation.domain.SystemClock
 import com.automattic.android.experimentation.remote.AssignmentsDtoMapper.toAssignments
 import com.squareup.moshi.Moshi
+import java.io.IOException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import okhttp3.OkHttpClient
@@ -34,10 +35,10 @@ internal class ExperimentRestClient(
         return withContext(Dispatchers.IO) {
             okHttpClient.newCall(request).execute().use { response ->
                 if (!response.isSuccessful) {
-                    Result.failure<Assignments>(Exception("Failed to fetch assignments"))
+                    Result.failure<Assignments>(IOException("Unexpected code $response"))
                 } else {
                     val fetchAssignmentDto = jsonAdapter.fromJson(response.body!!.source())
-                        ?: return@withContext Result.failure<Assignments>(Exception("Failed to parse assignments"))
+                        ?: return@withContext Result.failure<Assignments>(IOException("Failed to parse assignments"))
 
                     Result.success(
                         fetchAssignmentDto.toAssignments(clock.currentTimeMillis())

--- a/experimentation/src/main/java/com/automattic/android/experimentation/remote/ExperimentRestClient.kt
+++ b/experimentation/src/main/java/com/automattic/android/experimentation/remote/ExperimentRestClient.kt
@@ -15,6 +15,7 @@ internal class ExperimentRestClient(
     private val okHttpClient: OkHttpClient = OkHttpClient(),
     private val moshi: Moshi = Moshi.Builder().build(),
     private val jsonAdapter: AssignmentsDtoJsonAdapter = AssignmentsDtoJsonAdapter(moshi),
+    private val urlBuilder: UrlBuilder = ExPlatUrlBuilder(),
 ) {
 
     suspend fun fetchAssignments(
@@ -23,22 +24,7 @@ internal class ExperimentRestClient(
         anonymousId: String? = null,
     ): Result<Assignments> {
 
-        val url = HttpUrl.Builder()
-            .scheme("https")
-            .host("public-api.wordpress.com")
-            .addPathSegment("wpcom")
-            .addPathSegment("v2")
-            .addPathSegment("experiments")
-            .addPathSegment("0.1.0")
-            .addPathSegment("assignments")
-            .addPathSegment(platform)
-            .apply {
-                experimentNames.forEach { addQueryParameter("experiment_names", it) }
-                addQueryParameter("anon_id", anonymousId.orEmpty())
-            }
-            .build()
-
-        println(jsonAdapter.fromJson("foo"))
+        val url = urlBuilder.buildUrl(platform, experimentNames, anonymousId)
 
         val request = Request.Builder()
             .url(url)

--- a/experimentation/src/main/java/com/automattic/android/experimentation/remote/ExperimentRestClient.kt
+++ b/experimentation/src/main/java/com/automattic/android/experimentation/remote/ExperimentRestClient.kt
@@ -34,7 +34,7 @@ internal class ExperimentRestClient(
         return withContext(Dispatchers.IO) {
             okHttpClient.newCall(request).execute().use { response ->
                 if (!response.isSuccessful) {
-                    Result.failure<Assignments>(IOException("Unexpected code $response"))
+                    Result.failure(IOException("Unexpected code $response"))
                 } else {
                     runCatching {
                         val dto = jsonAdapter.fromJson(response.body!!.source())!!

--- a/experimentation/src/main/java/com/automattic/android/experimentation/remote/ExperimentRestClient.kt
+++ b/experimentation/src/main/java/com/automattic/android/experimentation/remote/ExperimentRestClient.kt
@@ -5,11 +5,11 @@ import com.automattic.android.experimentation.domain.Clock
 import com.automattic.android.experimentation.domain.SystemClock
 import com.automattic.android.experimentation.remote.AssignmentsDtoMapper.toAssignments
 import com.squareup.moshi.Moshi
-import java.io.IOException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import okhttp3.OkHttpClient
 import okhttp3.Request
+import java.io.IOException
 
 internal class ExperimentRestClient(
     private val okHttpClient: OkHttpClient = OkHttpClient(),
@@ -24,7 +24,6 @@ internal class ExperimentRestClient(
         experimentNames: List<String>,
         anonymousId: String? = null,
     ): Result<Assignments> {
-
         val url = urlBuilder.buildUrl(platform, experimentNames, anonymousId)
 
         val request = Request.Builder()

--- a/experimentation/src/main/java/com/automattic/android/experimentation/remote/ExperimentRestClient.kt
+++ b/experimentation/src/main/java/com/automattic/android/experimentation/remote/ExperimentRestClient.kt
@@ -1,21 +1,21 @@
 package com.automattic.android.experimentation.remote
 
 import com.automattic.android.experimentation.domain.Assignments
+import com.automattic.android.experimentation.domain.Clock
+import com.automattic.android.experimentation.domain.SystemClock
 import com.automattic.android.experimentation.remote.AssignmentsDtoMapper.toAssignments
-import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.Moshi
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import okhttp3.HttpUrl
 import okhttp3.OkHttpClient
 import okhttp3.Request
-import org.wordpress.android.fluxc.store.ExperimentStore
 
 internal class ExperimentRestClient(
     private val okHttpClient: OkHttpClient = OkHttpClient(),
     private val moshi: Moshi = Moshi.Builder().build(),
     private val jsonAdapter: AssignmentsDtoJsonAdapter = AssignmentsDtoJsonAdapter(moshi),
     private val urlBuilder: UrlBuilder = ExPlatUrlBuilder(),
+    private val clock: Clock = SystemClock(),
 ) {
 
     suspend fun fetchAssignments(
@@ -40,7 +40,7 @@ internal class ExperimentRestClient(
                         ?: return@withContext Result.failure<Assignments>(Exception("Failed to parse assignments"))
 
                     Result.success(
-                        fetchAssignmentDto.toAssignments(System.currentTimeMillis())
+                        fetchAssignmentDto.toAssignments(clock.currentTimeMillis())
                     )
                 }
             }

--- a/experimentation/src/main/java/com/automattic/android/experimentation/remote/ExperimentRestClient.kt
+++ b/experimentation/src/main/java/com/automattic/android/experimentation/remote/ExperimentRestClient.kt
@@ -1,0 +1,63 @@
+package com.automattic.android.experimentation.remote
+
+import com.automattic.android.experimentation.domain.Assignments
+import com.automattic.android.experimentation.remote.AssignmentsDtoMapper.toAssignments
+import com.squareup.moshi.JsonAdapter
+import com.squareup.moshi.Moshi
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import okhttp3.HttpUrl
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import org.wordpress.android.fluxc.store.ExperimentStore
+
+internal class ExperimentRestClient(
+    private val okHttpClient: OkHttpClient = OkHttpClient(),
+    private val moshi: Moshi = Moshi.Builder().build(),
+    private val jsonAdapter: AssignmentsDtoJsonAdapter = AssignmentsDtoJsonAdapter(moshi),
+) {
+
+    suspend fun fetchAssignments(
+        platform: String,
+        experimentNames: List<String>,
+        anonymousId: String? = null,
+    ): Result<Assignments> {
+
+        val url = HttpUrl.Builder()
+            .scheme("https")
+            .host("public-api.wordpress.com")
+            .addPathSegment("wpcom")
+            .addPathSegment("v2")
+            .addPathSegment("experiments")
+            .addPathSegment("0.1.0")
+            .addPathSegment("assignments")
+            .addPathSegment(platform)
+            .apply {
+                experimentNames.forEach { addQueryParameter("experiment_names", it) }
+                addQueryParameter("anon_id", anonymousId.orEmpty())
+            }
+            .build()
+
+        println(jsonAdapter.fromJson("foo"))
+
+        val request = Request.Builder()
+            .url(url)
+            .get()
+            .build()
+
+        return withContext(Dispatchers.IO) {
+            okHttpClient.newCall(request).execute().use { response ->
+                if (!response.isSuccessful) {
+                    Result.failure<Assignments>(Exception("Failed to fetch assignments"))
+                } else {
+                    val fetchAssignmentDto = jsonAdapter.fromJson(response.body!!.source())
+                        ?: return@withContext Result.failure<Assignments>(Exception("Failed to parse assignments"))
+
+                    Result.success(
+                        fetchAssignmentDto.toAssignments(System.currentTimeMillis())
+                    )
+                }
+            }
+        }
+    }
+}

--- a/experimentation/src/main/java/com/automattic/android/experimentation/remote/ExperimentRestClient.kt
+++ b/experimentation/src/main/java/com/automattic/android/experimentation/remote/ExperimentRestClient.kt
@@ -37,12 +37,10 @@ internal class ExperimentRestClient(
                 if (!response.isSuccessful) {
                     Result.failure<Assignments>(IOException("Unexpected code $response"))
                 } else {
-                    val fetchAssignmentDto = jsonAdapter.fromJson(response.body!!.source())
-                        ?: return@withContext Result.failure<Assignments>(IOException("Failed to parse assignments"))
-
-                    Result.success(
-                        fetchAssignmentDto.toAssignments(clock.currentTimeMillis())
-                    )
+                    runCatching {
+                        val dto = jsonAdapter.fromJson(response.body!!.source())!!
+                        dto.toAssignments(clock.currentTimeMillis())
+                    }
                 }
             }
         }

--- a/experimentation/src/main/java/com/automattic/android/experimentation/remote/UrlBuilder.kt
+++ b/experimentation/src/main/java/com/automattic/android/experimentation/remote/UrlBuilder.kt
@@ -1,0 +1,34 @@
+package com.automattic.android.experimentation.remote
+
+import okhttp3.HttpUrl
+
+fun interface UrlBuilder {
+    fun buildUrl(
+        platform: String,
+        experimentNames: List<String>,
+        anonymousId: String?,
+    ): HttpUrl
+}
+
+class ExPlatUrlBuilder : UrlBuilder {
+    override fun buildUrl(
+        platform: String,
+        experimentNames: List<String>,
+        anonymousId: String?
+    ): HttpUrl {
+        return HttpUrl.Builder()
+            .scheme("https")
+            .host("public-api.wordpress.com")
+            .addPathSegment("wpcom")
+            .addPathSegment("v2")
+            .addPathSegment("experiments")
+            .addPathSegment("0.1.0")
+            .addPathSegment("assignments")
+            .addPathSegment(platform)
+            .apply {
+                experimentNames.forEach { addQueryParameter("experiment_names", it) }
+                addQueryParameter("anon_id", anonymousId.orEmpty())
+            }
+            .build()
+    }
+}

--- a/experimentation/src/main/java/com/automattic/android/experimentation/remote/UrlBuilder.kt
+++ b/experimentation/src/main/java/com/automattic/android/experimentation/remote/UrlBuilder.kt
@@ -2,7 +2,7 @@ package com.automattic.android.experimentation.remote
 
 import okhttp3.HttpUrl
 
-fun interface UrlBuilder {
+internal fun interface UrlBuilder {
     fun buildUrl(
         platform: String,
         experimentNames: List<String>,
@@ -10,7 +10,7 @@ fun interface UrlBuilder {
     ): HttpUrl
 }
 
-class ExPlatUrlBuilder : UrlBuilder {
+internal class ExPlatUrlBuilder : UrlBuilder {
     override fun buildUrl(
         platform: String,
         experimentNames: List<String>,

--- a/experimentation/src/main/java/com/automattic/android/experimentation/remote/UrlBuilder.kt
+++ b/experimentation/src/main/java/com/automattic/android/experimentation/remote/UrlBuilder.kt
@@ -14,7 +14,7 @@ class ExPlatUrlBuilder : UrlBuilder {
     override fun buildUrl(
         platform: String,
         experimentNames: List<String>,
-        anonymousId: String?
+        anonymousId: String?,
     ): HttpUrl {
         return HttpUrl.Builder()
             .scheme("https")

--- a/experimentation/src/test/java/com/automattic/android/experimentation/remote/AssignmentsDtoMapperTest.kt
+++ b/experimentation/src/test/java/com/automattic/android/experimentation/remote/AssignmentsDtoMapperTest.kt
@@ -1,10 +1,10 @@
 package com.automattic.android.experimentation.remote
 
 import com.automattic.android.experimentation.domain.Assignments
-import com.automattic.android.experimentation.domain.Variation
-import com.automattic.android.experimentation.domain.Variation.*
+import com.automattic.android.experimentation.domain.Variation.Control
+import com.automattic.android.experimentation.domain.Variation.Treatment
 import com.automattic.android.experimentation.remote.AssignmentsDtoMapper.toAssignments
-import org.junit.Assert.*
+import org.junit.Assert.assertEquals
 import org.junit.Test
 
 class AssignmentsDtoMapperTest {
@@ -17,18 +17,18 @@ class AssignmentsDtoMapperTest {
             variations = mapOf(
                 "experiment1" to "treatment1",
                 "experiment2" to "control",
-                "experiment3" to null
+                "experiment3" to null,
             ),
-            ttl = ttl
+            ttl = ttl,
         )
         val expected = Assignments(
             variations = mapOf(
                 "experiment1" to Treatment("treatment1"),
                 "experiment2" to Control,
-                "experiment3" to Control
+                "experiment3" to Control,
             ),
             ttl = ttl,
-            fetchedAt = fetchedAt
+            fetchedAt = fetchedAt,
         )
 
         val result = dto.toAssignments(fetchedAt)

--- a/experimentation/src/test/java/com/automattic/android/experimentation/remote/AssignmentsDtoMapperTest.kt
+++ b/experimentation/src/test/java/com/automattic/android/experimentation/remote/AssignmentsDtoMapperTest.kt
@@ -1,0 +1,38 @@
+package com.automattic.android.experimentation.remote
+
+import com.automattic.android.experimentation.domain.Assignments
+import com.automattic.android.experimentation.domain.Variation
+import com.automattic.android.experimentation.domain.Variation.*
+import com.automattic.android.experimentation.remote.AssignmentsDtoMapper.toAssignments
+import org.junit.Assert.*
+import org.junit.Test
+
+class AssignmentsDtoMapperTest {
+
+    @Test
+    fun `mapping from dto to domain object is successful`() {
+        val ttl = 100
+        val fetchedAt = 123456L
+        val dto = AssignmentsDto(
+            variations = mapOf(
+                "experiment1" to "treatment1",
+                "experiment2" to "control",
+                "experiment3" to null
+            ),
+            ttl = ttl
+        )
+        val expected = Assignments(
+            variations = mapOf(
+                "experiment1" to Treatment("treatment1"),
+                "experiment2" to Control,
+                "experiment3" to Control
+            ),
+            ttl = ttl,
+            fetchedAt = fetchedAt
+        )
+
+        val result = dto.toAssignments(fetchedAt)
+
+        assertEquals(expected, result)
+    }
+}

--- a/experimentation/src/test/java/com/automattic/android/experimentation/remote/ExperimentRestClientTest.kt
+++ b/experimentation/src/test/java/com/automattic/android/experimentation/remote/ExperimentRestClientTest.kt
@@ -8,10 +8,10 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertTrue
 
 internal class ExperimentRestClientTest {
 

--- a/experimentation/src/test/java/com/automattic/android/experimentation/remote/ExperimentRestClientTest.kt
+++ b/experimentation/src/test/java/com/automattic/android/experimentation/remote/ExperimentRestClientTest.kt
@@ -3,18 +3,15 @@
 package com.automattic.android.experimentation.remote
 
 import com.automattic.android.experimentation.domain.Assignments
-import com.automattic.android.experimentation.domain.Clock
-import com.automattic.android.experimentation.domain.Variation
-import com.automattic.android.experimentation.domain.Variation.*
-import kotlin.test.assertEquals
-import kotlin.test.assertTrue
+import com.automattic.android.experimentation.domain.Variation.Treatment
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
-import okhttp3.HttpUrl
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.Before
 import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 internal class ExperimentRestClientTest {
 
@@ -25,7 +22,7 @@ internal class ExperimentRestClientTest {
     fun setUp() {
         sut = ExperimentRestClient(
             urlBuilder = { _, _, _ -> server.url("/").newBuilder().build() },
-            clock = { TEST_TIMESTAMP }
+            clock = { TEST_TIMESTAMP },
         )
     }
 
@@ -36,11 +33,11 @@ internal class ExperimentRestClientTest {
             Assignments(
                 variations = mapOf(
                     "experiment1" to Treatment("variation1"),
-                    "experiment2" to Treatment("variation2")
+                    "experiment2" to Treatment("variation2"),
                 ),
                 ttl = 3600,
-                fetchedAt = TEST_TIMESTAMP
-            )
+                fetchedAt = TEST_TIMESTAMP,
+            ),
         )
 
         val result = sut.fetchAssignments("", emptyList())
@@ -79,7 +76,7 @@ internal class ExperimentRestClientTest {
                         },
                         "ttl": 3600
                     }
-                    """.trimIndent()
+            """.trimIndent(),
         )
     }
 }

--- a/experimentation/src/test/java/com/automattic/android/experimentation/remote/ExperimentRestClientTest.kt
+++ b/experimentation/src/test/java/com/automattic/android/experimentation/remote/ExperimentRestClientTest.kt
@@ -1,0 +1,85 @@
+@file:OptIn(ExperimentalCoroutinesApi::class)
+
+package com.automattic.android.experimentation.remote
+
+import com.automattic.android.experimentation.domain.Assignments
+import com.automattic.android.experimentation.domain.Clock
+import com.automattic.android.experimentation.domain.Variation
+import com.automattic.android.experimentation.domain.Variation.*
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import okhttp3.HttpUrl
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.Before
+import org.junit.Test
+
+internal class ExperimentRestClientTest {
+
+    private val server: MockWebServer = MockWebServer()
+    private lateinit var sut: ExperimentRestClient
+
+    @Before
+    fun setUp() {
+        sut = ExperimentRestClient(
+            urlBuilder = { _, _, _ -> server.url("/").newBuilder().build() },
+            clock = { TEST_TIMESTAMP }
+        )
+    }
+
+    @Test
+    fun `fetching assignments from api is successful`() = runTest {
+        server.enqueue(SUCCESSFUL_RESPONSE)
+        val expectedResponse = Result.success(
+            Assignments(
+                variations = mapOf(
+                    "experiment1" to Treatment("variation1"),
+                    "experiment2" to Treatment("variation2")
+                ),
+                ttl = 3600,
+                fetchedAt = TEST_TIMESTAMP
+            )
+        )
+
+        val result = sut.fetchAssignments("", emptyList())
+
+        assertEquals(expectedResponse, result)
+    }
+
+    @Test
+    fun `fetching assignments from an unavailable api is a failure`() = runTest {
+        val errorCode = 503
+        server.enqueue(MockResponse().setResponseCode(errorCode))
+
+        val result = sut.fetchAssignments("", emptyList())
+
+        assertTrue(result.isFailure)
+        assertTrue(result.exceptionOrNull()!!.message!!.contains("$errorCode"))
+    }
+
+    @Test
+    fun `fetching assignments from an api with unexpected response is a failure`() = runTest {
+        server.enqueue(MockResponse().setResponseCode(200).setBody("unexpected response"))
+
+        val result = sut.fetchAssignments("", emptyList())
+
+        assertTrue(result.isFailure)
+    }
+
+    companion object {
+        private const val TEST_TIMESTAMP = 123456789L
+        private val SUCCESSFUL_RESPONSE = MockResponse().setResponseCode(200).setBody(
+            """
+                    {
+                        "variations": {
+                            "experiment1": "variation1",
+                            "experiment2": "variation2"
+                        },
+                        "ttl": 3600
+                    }
+                    """.trimIndent()
+        )
+    }
+}

--- a/ktlint.gradle
+++ b/ktlint.gradle
@@ -10,6 +10,7 @@ task ktlintFormat(type: JavaExec, group: "formatting") {
     classpath = configurations.ktlint
     main = "com.pinterest.ktlint.Main"
     args "-F", "src/**/*.kt"
+    jvmArgs("--add-opens", "java.base/java.lang=ALL-UNNAMED")
 }
 
 task ciktlint(type: JavaExec) {

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,6 @@
 pluginManagement {
     gradle.ext.kotlinVersion = '1.9.24'
+    gradle.ext.kspVersion = '1.9.24-1.0.20'
     gradle.ext.agpVersion = '8.1.0'
     gradle.ext.automatticPublishToS3Version = '0.8.0'
     gradle.ext.dependencyAnalysisVersion = '1.28.0'
@@ -11,6 +12,7 @@ pluginManagement {
         id 'com.automattic.android.publish-to-s3' version gradle.ext.automatticPublishToS3Version
         id 'androidx.benchmark' version '1.2.4'
         id "com.autonomousapps.dependency-analysis" version gradle.ext.dependencyAnalysisVersion
+        id 'com.google.devtools.ksp' version gradle.ext.kspVersion
     }
     repositories {
         maven {


### PR DESCRIPTION
### Description

This PR is a first one of a few that aim to remove `FluxC` as a dependency for `experimantation` project.

In this PR I introduce `ExperimentRestClient` with logic of parsing fetched JSON and mapping it to domain models.

I decided to not introduce a feature branch to keep things simpler: newly introduced classes are not visible to consumers (except domain models, which are useless on its own) so it shouldn't cause confusion.

The logic is based on FluxC implementation, especially `org.wordpress.android.fluxc.network.rest.wpcom.experiments.ExperimentRestClient`

### How to test?

At this moment, testing is not required or possible due to lack of an entry point. The testing is covered with unit tests, and in next PRs I'll prepare some test scenarios.