### PR TITLE
Introduce file-based persistence for Experimentation module

### DIFF
--- a/experimentation/src/main/java/com/automattic/android/experimentation/local/FileBasedCache.kt
+++ b/experimentation/src/main/java/com/automattic/android/experimentation/local/FileBasedCache.kt
@@ -1,0 +1,37 @@
+package com.automattic.android.experimentation.local
+
+import com.automattic.android.experimentation.domain.Assignments
+import com.automattic.android.experimentation.remote.AssignmentsDtoJsonAdapter
+import com.automattic.android.experimentation.remote.AssignmentsDtoMapper.toAssignments
+import com.automattic.android.experimentation.remote.AssignmentsDtoMapper.toDto
+import com.squareup.moshi.Moshi
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.io.File
+
+internal class FileBasedCache(
+    private val cacheDir: File,
+    private val moshi: Moshi = Moshi.Builder().build(),
+    private val jsonAdapter: AssignmentsDtoJsonAdapter = AssignmentsDtoJsonAdapter(moshi),
+) {
+
+    private val assignmentsFile = File(cacheDir, "assignments.json")
+
+    suspend fun getAssignments(): Assignments? {
+        return withContext(Dispatchers.IO) {
+            assignmentsFile.takeIf { it.exists() }?.readText()?.let { json ->
+                val dto = jsonAdapter.fromJson(json)
+                dto?.toAssignments(null)
+            }
+        }
+    }
+
+    suspend fun saveAssignments(assignments: Assignments) {
+        withContext(Dispatchers.IO) {
+            val dto = assignments.toDto()
+            val json = jsonAdapter.serializeNulls().toJson(dto)
+
+            assignmentsFile.writeText(json)
+        }
+    }
+}

--- a/experimentation/src/main/java/com/automattic/android/experimentation/remote/AssignmentsDto.kt
+++ b/experimentation/src/main/java/com/automattic/android/experimentation/remote/AssignmentsDto.kt
@@ -9,4 +9,6 @@ internal data class AssignmentsDto(
     val variations: Map<String, String?>,
     @Json(name = "ttl")
     val ttl: Int,
+    @Json(name = "fetchedAt")
+    val fetchedAt: Long?,
 )

--- a/experimentation/src/main/java/com/automattic/android/experimentation/remote/AssignmentsDto.kt
+++ b/experimentation/src/main/java/com/automattic/android/experimentation/remote/AssignmentsDto.kt
@@ -9,6 +9,4 @@ internal data class AssignmentsDto(
     val variations: Map<String, String?>,
     @Json(name = "ttl")
     val ttl: Int,
-    @Json(name = "fetchedAt")
-    val fetchedAt: Long?,
 )

--- a/experimentation/src/main/java/com/automattic/android/experimentation/remote/AssignmentsDtoMapper.kt
+++ b/experimentation/src/main/java/com/automattic/android/experimentation/remote/AssignmentsDtoMapper.kt
@@ -4,7 +4,7 @@ import com.automattic.android.experimentation.domain.Assignments
 import com.automattic.android.experimentation.domain.Variation
 
 internal object AssignmentsDtoMapper {
-    fun AssignmentsDto.toAssignments(externalFetchedAt: Long?): Assignments {
+    fun AssignmentsDto.toAssignments(fetchedAt: Long): Assignments {
         return Assignments(
             variations = variations.mapValues { (key, value) ->
                 if (value == null || value == "control") {
@@ -14,10 +14,10 @@ internal object AssignmentsDtoMapper {
                 }
             },
             ttl = ttl,
-            fetchedAt = externalFetchedAt ?: this.fetchedAt ?: 0,
+            fetchedAt = fetchedAt,
         )
     }
-    fun Assignments.toDto(): AssignmentsDto {
+    fun Assignments.toDto(): Pair<AssignmentsDto, Long> {
         return AssignmentsDto(
             variations = variations.mapValues { (_, value) ->
                 when (value) {
@@ -26,7 +26,6 @@ internal object AssignmentsDtoMapper {
                 }
             },
             ttl = ttl,
-            fetchedAt = fetchedAt,
-        )
+        ) to fetchedAt
     }
 }

--- a/experimentation/src/main/java/com/automattic/android/experimentation/remote/AssignmentsDtoMapper.kt
+++ b/experimentation/src/main/java/com/automattic/android/experimentation/remote/AssignmentsDtoMapper.kt
@@ -4,10 +4,11 @@ import com.automattic.android.experimentation.domain.Assignments
 import com.automattic.android.experimentation.domain.Variation
 
 internal object AssignmentsDtoMapper {
+    private const val CONTROL = "control"
     fun AssignmentsDto.toAssignments(fetchedAt: Long): Assignments {
         return Assignments(
             variations = variations.mapValues { (_, value) ->
-                if (value == null || value == "control") {
+                if (value == null || value == CONTROL) {
                     Variation.Control
                 } else {
                     Variation.Treatment(value)
@@ -21,7 +22,7 @@ internal object AssignmentsDtoMapper {
         return AssignmentsDto(
             variations = variations.mapValues { (_, value) ->
                 when (value) {
-                    is Variation.Control -> null
+                    is Variation.Control -> CONTROL
                     is Variation.Treatment -> value.name
                 }
             },

--- a/experimentation/src/main/java/com/automattic/android/experimentation/remote/AssignmentsDtoMapper.kt
+++ b/experimentation/src/main/java/com/automattic/android/experimentation/remote/AssignmentsDtoMapper.kt
@@ -4,13 +4,25 @@ import com.automattic.android.experimentation.domain.Assignments
 import com.automattic.android.experimentation.domain.Variation
 
 internal object AssignmentsDtoMapper {
-    fun AssignmentsDto.toAssignments(fetchedAt: Long): Assignments {
+    fun AssignmentsDto.toAssignments(externalFetchedAt: Long?): Assignments {
         return Assignments(
             variations = variations.mapValues { (key, value) ->
                 if (value == null || value == "control") {
                     Variation.Control
                 } else {
                     Variation.Treatment(value)
+                }
+            },
+            ttl = ttl,
+            fetchedAt = externalFetchedAt ?: this.fetchedAt ?: 0,
+        )
+    }
+    fun Assignments.toDto(): AssignmentsDto {
+        return AssignmentsDto(
+            variations = variations.mapValues { (_, value) ->
+                when (value) {
+                    is Variation.Control -> null
+                    is Variation.Treatment -> value.name
                 }
             },
             ttl = ttl,

--- a/experimentation/src/main/java/com/automattic/android/experimentation/remote/AssignmentsDtoMapper.kt
+++ b/experimentation/src/main/java/com/automattic/android/experimentation/remote/AssignmentsDtoMapper.kt
@@ -8,6 +8,8 @@ internal object AssignmentsDtoMapper {
     fun AssignmentsDto.toAssignments(fetchedAt: Long): Assignments {
         return Assignments(
             variations = variations.mapValues { (_, value) ->
+                // API returns null for control group, but the FluxC implementation covered case
+                // in which API returns "control" String. To be safe, we handle both cases here
                 if (value == null || value == CONTROL) {
                     Variation.Control
                 } else {

--- a/experimentation/src/test/java/com/automattic/android/experimentation/local/FileBasedCacheTest.kt
+++ b/experimentation/src/test/java/com/automattic/android/experimentation/local/FileBasedCacheTest.kt
@@ -16,7 +16,7 @@ internal class FileBasedCacheTest {
     private lateinit var sut: FileBasedCache
 
     @Test
-    fun `saving and reading saved assignments is successful`() = runTest {
+    fun `saving and reading assignments is successful`() = runTest {
         sut = fileBasedCache()
         sut.saveAssignments(TEST_ASSIGNMENTS)
 
@@ -26,7 +26,7 @@ internal class FileBasedCacheTest {
     }
 
     @Test
-    fun `saving different assignments on top of previously saved is successful`() = runTest {
+    fun `updating assignments is successful`() = runTest {
         sut = fileBasedCache()
         val updatedTestAssignments = TEST_ASSIGNMENTS.copy(
             variations = mapOf(

--- a/experimentation/src/test/java/com/automattic/android/experimentation/local/FileBasedCacheTest.kt
+++ b/experimentation/src/test/java/com/automattic/android/experimentation/local/FileBasedCacheTest.kt
@@ -1,0 +1,68 @@
+package com.automattic.android.experimentation.local
+
+import com.automattic.android.experimentation.domain.Assignments
+import com.automattic.android.experimentation.domain.Variation.Control
+import com.automattic.android.experimentation.domain.Variation.Treatment
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import kotlin.io.path.createTempDirectory
+
+@OptIn(ExperimentalCoroutinesApi::class)
+internal class FileBasedCacheTest {
+
+    private lateinit var sut: FileBasedCache
+
+    @Test
+    fun `saving and reading saved assignments is successful`() = runTest {
+        sut = fileBasedCache()
+        sut.saveAssignments(TEST_ASSIGNMENTS)
+
+        val result = sut.getAssignments()
+
+        assertEquals(TEST_ASSIGNMENTS, result)
+    }
+
+    @Test
+    fun `saving different assignments on top of previously saved is successful`() = runTest {
+        sut = fileBasedCache()
+        val updatedTestAssignments = TEST_ASSIGNMENTS.copy(
+            variations = mapOf(
+                "experiment1" to Treatment("variation1"),
+                "experiment2" to Control,
+            ),
+            fetchedAt = 987654321L,
+        )
+        sut.saveAssignments(TEST_ASSIGNMENTS)
+
+        sut.saveAssignments(updatedTestAssignments)
+        val result = sut.getAssignments()
+
+        assertEquals(updatedTestAssignments, result)
+    }
+
+    @Test
+    fun `getting assignments from empty cache returns no results`() = runTest {
+        sut = fileBasedCache()
+
+        val result = sut.getAssignments()
+
+        assertNull(result)
+    }
+
+    private fun fileBasedCache() =
+        FileBasedCache(cacheDir = createTempDirectory().toFile())
+
+    companion object {
+        private val TEST_ASSIGNMENTS = Assignments(
+            variations = mapOf(
+                "experiment1" to Control,
+                "experiment2" to Treatment("variation2"),
+            ),
+            ttl = 3600,
+            fetchedAt = 123456789L,
+        )
+    }
+}

--- a/experimentation/src/test/java/com/automattic/android/experimentation/local/FileBasedCacheTest.kt
+++ b/experimentation/src/test/java/com/automattic/android/experimentation/local/FileBasedCacheTest.kt
@@ -13,11 +13,9 @@ import kotlin.io.path.createTempDirectory
 @OptIn(ExperimentalCoroutinesApi::class)
 internal class FileBasedCacheTest {
 
-    private lateinit var sut: FileBasedCache
-
     @Test
     fun `saving and reading assignments is successful`() = runTest {
-        sut = fileBasedCache()
+        val sut = fileBasedCache()
         sut.saveAssignments(TEST_ASSIGNMENTS)
 
         val result = sut.getAssignments()
@@ -27,7 +25,7 @@ internal class FileBasedCacheTest {
 
     @Test
     fun `updating assignments is successful`() = runTest {
-        sut = fileBasedCache()
+        val sut = fileBasedCache()
         val updatedTestAssignments = TEST_ASSIGNMENTS.copy(
             variations = mapOf(
                 "experiment1" to Treatment("variation1"),
@@ -45,7 +43,7 @@ internal class FileBasedCacheTest {
 
     @Test
     fun `getting assignments from empty cache returns no results`() = runTest {
-        sut = fileBasedCache()
+        val sut = fileBasedCache()
 
         val result = sut.getAssignments()
 


### PR DESCRIPTION
### Description

Similarly to #237 , this PR is part of "defluxcification" of experiments module.

In this PR, I'm introducing a persistence layer that will work as a cache. In original implementation (FluxC), this was handled via saving a json file in shared preferences. I think a simple file would fit here also well, I don't see a compiling arguments to use shared preferences, while it introduces some more complexity.

### How to test?

The same as in #237 at this moment unit tests have to suffice. In next PRs, I'll bring some test cases that will cover the persistance. 