### PR TITLE
Experimentation: replace FluxC with internal components

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,6 @@ ext {
 
 ext {
     // libs
-    wordPressFluxCVersion = '1.36.0'
     wordPressUtilsVersion = '2.3.0'
 
     // main

--- a/build.gradle
+++ b/build.gradle
@@ -39,9 +39,6 @@ ext {
 
 
 ext {
-    // libs
-    wordPressUtilsVersion = '2.3.0'
-
     // main
     androidxAnnotationVersion = "1.1.0"
     androidxAppcompatVersion = '1.2.0'

--- a/experimentation/build.gradle
+++ b/experimentation/build.gradle
@@ -46,9 +46,6 @@ dependencies {
     // Coroutines
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlinxCoroutinesVersion"
 
-    //WordPress utils
-    implementation "org.wordpress:utils:$wordPressUtilsVersion"
-
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$kotlinxCoroutinesVersion"
     testImplementation "junit:junit:$junitVersion"
     testImplementation "org.assertj:assertj-core:$assertjVersion"

--- a/experimentation/build.gradle
+++ b/experimentation/build.gradle
@@ -11,7 +11,6 @@ repositories {
         url "https://a8c-libs.s3.amazonaws.com/android"
         content {
             includeGroup "org.wordpress"
-            includeGroup "org.wordpress.fluxc"
             includeGroup "org.wordpress.wellsql"
         }
     }
@@ -46,9 +45,6 @@ dependencies {
 
     // Coroutines
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlinxCoroutinesVersion"
-
-    //FluxC
-    implementation "org.wordpress:fluxc:$wordPressFluxCVersion"
 
     //WordPress utils
     implementation "org.wordpress:utils:$wordPressUtilsVersion"

--- a/experimentation/build.gradle
+++ b/experimentation/build.gradle
@@ -11,7 +11,6 @@ repositories {
         url "https://a8c-libs.s3.amazonaws.com/android"
         content {
             includeGroup "org.wordpress"
-            includeGroup "org.wordpress.wellsql"
         }
     }
 }

--- a/experimentation/src/main/java/com/automattic/android/experimentation/ExPlat.kt
+++ b/experimentation/src/main/java/com/automattic/android/experimentation/ExPlat.kt
@@ -12,10 +12,9 @@ import com.automattic.android.experimentation.remote.ExperimentRestClient
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
-import org.wordpress.android.fluxc.store.ExperimentStore.Platform
 
 class ExPlat internal constructor(
-    private val platform: Platform,
+    private val platform: String,
     private val experiments: Set<Experiment>,
     private val logger: ExperimentLogger,
     private val coroutineScope: CoroutineScope,
@@ -98,7 +97,7 @@ class ExPlat internal constructor(
     }
 
     private suspend fun fetchAssignments() =
-        restClient.fetchAssignments(platform.value, experimentIdentifiers).fold(
+        restClient.fetchAssignments(platform, experimentIdentifiers).fold(
             onSuccess = {
                 logger.d("ExPlat: fetching assignments successful with result: $it")
             },

--- a/experimentation/src/main/java/com/automattic/android/experimentation/ExPlat.kt
+++ b/experimentation/src/main/java/com/automattic/android/experimentation/ExPlat.kt
@@ -70,7 +70,7 @@ class ExPlat internal constructor(
         logger.d("ExPlat: clearing cached assignments and active variations")
         activeVariations.clear()
         coroutineScope.launch {
-            repository.clear()
+            repository.clearCache()
         }
     }
 

--- a/experimentation/src/main/java/com/automattic/android/experimentation/ExPlat.kt
+++ b/experimentation/src/main/java/com/automattic/android/experimentation/ExPlat.kt
@@ -69,9 +69,7 @@ class ExPlat internal constructor(
     fun clear() {
         logger.d("ExPlat: clearing cached assignments and active variations")
         activeVariations.clear()
-        coroutineScope.launch {
-            repository.clearCache()
-        }
+        coroutineScope.launch { repository.clearCache() }
     }
 
     private fun refresh(refreshStrategy: RefreshStrategy) {
@@ -83,11 +81,8 @@ class ExPlat internal constructor(
     private fun getAssignments(refreshStrategy: RefreshStrategy): Assignments {
         val cachedAssignments: Assignments =
             runBlocking { repository.getCached() } ?: Assignments(emptyMap(), 0, 0)
-        if (refreshStrategy == ALWAYS || (
-                refreshStrategy == IF_STALE && assignmentsValidator.isStale(
-                    cachedAssignments,
-                )
-                )
+        if (refreshStrategy == ALWAYS ||
+            (refreshStrategy == IF_STALE && assignmentsValidator.isStale(cachedAssignments))
         ) {
             coroutineScope.launch { fetchAssignments() }
         }

--- a/experimentation/src/main/java/com/automattic/android/experimentation/ExPlat.kt
+++ b/experimentation/src/main/java/com/automattic/android/experimentation/ExPlat.kt
@@ -6,7 +6,7 @@ import com.automattic.android.experimentation.ExPlat.RefreshStrategy.NEVER
 import com.automattic.android.experimentation.domain.Assignments
 import com.automattic.android.experimentation.domain.AssignmentsValidator
 import com.automattic.android.experimentation.domain.Variation
-import com.automattic.android.experimentation.domain.Variation.*
+import com.automattic.android.experimentation.domain.Variation.Control
 import com.automattic.android.experimentation.local.FileBasedCache
 import com.automattic.android.experimentation.remote.ExperimentRestClient
 import kotlinx.coroutines.CoroutineScope
@@ -81,7 +81,7 @@ class ExPlat internal constructor(
     }
 
     private fun getAssignments(refreshStrategy: RefreshStrategy): Assignments {
-        val cachedAssignments: Assignments = runBlocking {  cache.getAssignments() } ?: Assignments(emptyMap(), 0, 0)
+        val cachedAssignments: Assignments = runBlocking { cache.getAssignments() } ?: Assignments(emptyMap(), 0, 0)
         if (refreshStrategy == ALWAYS || (refreshStrategy == IF_STALE && assignmentsValidator.isStale(cachedAssignments))) {
             coroutineScope.launch { fetchAssignments() }
         }
@@ -94,7 +94,7 @@ class ExPlat internal constructor(
         },
         onFailure = {
             appLogWrapper.d(T.API, "ExPlat: fetching assignments failed with result: $it")
-        }
+        },
     )
     private enum class RefreshStrategy { ALWAYS, IF_STALE, NEVER }
 }

--- a/experimentation/src/main/java/com/automattic/android/experimentation/ExperimentLogger.kt
+++ b/experimentation/src/main/java/com/automattic/android/experimentation/ExperimentLogger.kt
@@ -1,0 +1,6 @@
+package com.automattic.android.experimentation
+
+interface ExperimentLogger {
+    fun d(message: String)
+    fun e(message: String, throwable: Throwable)
+}

--- a/experimentation/src/main/java/com/automattic/android/experimentation/domain/Assignments.kt
+++ b/experimentation/src/main/java/com/automattic/android/experimentation/domain/Assignments.kt
@@ -2,6 +2,6 @@ package com.automattic.android.experimentation.domain
 
 data class Assignments(
     val variations: Map<String, Variation>,
-    val ttl: Int,
+    val timeToLive: Int,
     val fetchedAt: Long,
 )

--- a/experimentation/src/main/java/com/automattic/android/experimentation/domain/AssignmentsValidator.kt
+++ b/experimentation/src/main/java/com/automattic/android/experimentation/domain/AssignmentsValidator.kt
@@ -1,0 +1,10 @@
+package com.automattic.android.experimentation.domain
+
+internal class AssignmentsValidator(private val clock: Clock) {
+
+    private val Assignments.expiresAt
+        get() = fetchedAt + timeToLive
+
+    fun isStale(assignments: Assignments): Boolean =
+        clock.currentTimeSeconds() > assignments.expiresAt
+}

--- a/experimentation/src/main/java/com/automattic/android/experimentation/domain/Clock.kt
+++ b/experimentation/src/main/java/com/automattic/android/experimentation/domain/Clock.kt
@@ -1,9 +1,9 @@
 package com.automattic.android.experimentation.domain
 
 internal fun interface Clock {
-    fun currentTimeMillis(): Long
+    fun currentTimeSeconds(): Long
 }
 
 internal class SystemClock : Clock {
-    override fun currentTimeMillis(): Long = System.currentTimeMillis()
+    override fun currentTimeSeconds(): Long = System.currentTimeMillis() / 1000
 }

--- a/experimentation/src/main/java/com/automattic/android/experimentation/local/FileBasedCache.kt
+++ b/experimentation/src/main/java/com/automattic/android/experimentation/local/FileBasedCache.kt
@@ -11,7 +11,7 @@ import kotlinx.coroutines.withContext
 import java.io.File
 
 internal class FileBasedCache(
-    private val cacheDir: File,
+    cacheDir: File,
     private val moshi: Moshi = Moshi.Builder().build(),
     private val jsonAdapter: AssignmentsDtoJsonAdapter = AssignmentsDtoJsonAdapter(moshi),
 ) {
@@ -45,6 +45,12 @@ internal class FileBasedCache(
 
             val wrapperJson = wrapperAdapter.toJson(mapOf(fetchedAt to dtoJson))
             assignmentsFile.writeText(wrapperJson)
+        }
+    }
+
+    suspend fun clear() {
+        withContext(Dispatchers.IO) {
+            assignmentsFile.delete()
         }
     }
 }

--- a/experimentation/src/main/java/com/automattic/android/experimentation/remote/AssignmentsDtoMapper.kt
+++ b/experimentation/src/main/java/com/automattic/android/experimentation/remote/AssignmentsDtoMapper.kt
@@ -16,7 +16,7 @@ internal object AssignmentsDtoMapper {
                     Variation.Treatment(value)
                 }
             },
-            ttl = ttl,
+            timeToLive = ttl,
             fetchedAt = fetchedAt,
         )
     }
@@ -28,7 +28,7 @@ internal object AssignmentsDtoMapper {
                     is Variation.Treatment -> value.name
                 }
             },
-            ttl = ttl,
+            ttl = timeToLive,
         ) to fetchedAt
     }
 }

--- a/experimentation/src/main/java/com/automattic/android/experimentation/remote/AssignmentsDtoMapper.kt
+++ b/experimentation/src/main/java/com/automattic/android/experimentation/remote/AssignmentsDtoMapper.kt
@@ -8,8 +8,8 @@ internal object AssignmentsDtoMapper {
     fun AssignmentsDto.toAssignments(fetchedAt: Long): Assignments {
         return Assignments(
             variations = variations.mapValues { (_, value) ->
-                // API returns null for control group, but the FluxC implementation covered case
-                // in which API returns "control" String. To be safe, we handle both cases here
+                // API returns null for control group, but a previous implementation (back from FluxC)
+                // covered a case in which API returns "control" String. To be safe, we handle both cases.
                 if (value == null || value == CONTROL) {
                     Variation.Control
                 } else {

--- a/experimentation/src/main/java/com/automattic/android/experimentation/remote/ExperimentRestClient.kt
+++ b/experimentation/src/main/java/com/automattic/android/experimentation/remote/ExperimentRestClient.kt
@@ -38,7 +38,7 @@ internal class ExperimentRestClient(
                 } else {
                     runCatching {
                         val dto = jsonAdapter.fromJson(response.body!!.source())!!
-                        dto.toAssignments(clock.currentTimeMillis())
+                        dto.toAssignments(clock.currentTimeSeconds())
                     }
                 }
             }

--- a/experimentation/src/main/java/com/automattic/android/experimentation/repository/AssignmentsRepository.kt
+++ b/experimentation/src/main/java/com/automattic/android/experimentation/repository/AssignmentsRepository.kt
@@ -32,7 +32,7 @@ internal class AssignmentsRepository(
         return cache.getAssignments()
     }
 
-    suspend fun clear() {
+    suspend fun clearCache() {
         cache.clear()
     }
 }

--- a/experimentation/src/main/java/com/automattic/android/experimentation/repository/AssignmentsRepository.kt
+++ b/experimentation/src/main/java/com/automattic/android/experimentation/repository/AssignmentsRepository.kt
@@ -1,0 +1,38 @@
+package com.automattic.android.experimentation.repository
+
+import com.automattic.android.experimentation.domain.Assignments
+import com.automattic.android.experimentation.local.FileBasedCache
+import com.automattic.android.experimentation.remote.ExperimentRestClient
+
+internal class AssignmentsRepository(
+    private val experimentRestClient: ExperimentRestClient,
+    private val cache: FileBasedCache,
+) {
+
+    suspend fun fetch(
+        platform: String,
+        experimentNames: List<String>,
+        anonymousId: String? = null,
+    ): Result<Assignments> {
+        val fetchResult =
+            experimentRestClient.fetchAssignments(platform, experimentNames, anonymousId)
+
+        return fetchResult.fold(
+            onFailure = {
+                Result.failure(it)
+            },
+            onSuccess = { assignments ->
+                cache.saveAssignments(assignments)
+                Result.success(assignments)
+            },
+        )
+    }
+
+    suspend fun getCached(): Assignments? {
+        return cache.getAssignments()
+    }
+
+    suspend fun clear() {
+        cache.clear()
+    }
+}

--- a/experimentation/src/test/java/com/automattic/android/experimentation/ExPlatTest.kt
+++ b/experimentation/src/test/java/com/automattic/android/experimentation/ExPlatTest.kt
@@ -8,12 +8,12 @@ import com.automattic.android.experimentation.domain.Variation.Control
 import com.automattic.android.experimentation.domain.Variation.Treatment
 import com.automattic.android.experimentation.local.FileBasedCache
 import com.automattic.android.experimentation.remote.ExperimentRestClient
+import com.automattic.android.experimentation.repository.AssignmentsRepository
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runBlockingTest
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Ignore
 import org.junit.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
@@ -88,7 +88,6 @@ class ExPlatTest {
     }
 
     @Test
-    @Ignore("This test fails because the cache is not being saved")
     fun `force refresh is successful when cache is fresh `() = runBlockingTest {
         exPlat = createExPlat(
             isDebug = true,
@@ -101,7 +100,6 @@ class ExPlatTest {
 
         verify(cache).saveAssignments(fetchedAssignments)
     }
-
 
     @Test
     fun `clear calls experiment store`() = runBlockingTest {
@@ -240,9 +238,8 @@ class ExPlatTest {
             logger = logger,
             coroutineScope = CoroutineScope(Dispatchers.Unconfined),
             isDebug = isDebug,
-            cache = cache,
             assignmentsValidator = AssignmentsValidator(SystemClock()),
-            restClient = restClient,
+            repository = AssignmentsRepository(restClient, cache),
         )
 
     private suspend fun setupAssignments(cachedAssignments: Assignments?, fetchedAssignments: Assignments) {

--- a/experimentation/src/test/java/com/automattic/android/experimentation/ExPlatTest.kt
+++ b/experimentation/src/test/java/com/automattic/android/experimentation/ExPlatTest.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runBlockingTest
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.Ignore
 import org.junit.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
@@ -85,6 +86,22 @@ class ExPlatTest {
 
         verify(restClient, times(1)).fetchAssignments(eq(platform), any(), anyOrNull())
     }
+
+    @Test
+    @Ignore("This test fails because the cache is not being saved")
+    fun `force refresh is successful when cache is fresh `() = runBlockingTest {
+        exPlat = createExPlat(
+            isDebug = true,
+            experiments = setOf(dummyExperiment),
+        )
+        val fetchedAssignments = buildAssignments()
+        setupAssignments(cachedAssignments = buildAssignments(isStale = true), fetchedAssignments = fetchedAssignments)
+
+        exPlat.forceRefresh()
+
+        verify(cache).saveAssignments(fetchedAssignments)
+    }
+
 
     @Test
     fun `clear calls experiment store`() = runBlockingTest {

--- a/experimentation/src/test/java/com/automattic/android/experimentation/ExPlatTest.kt
+++ b/experimentation/src/test/java/com/automattic/android/experimentation/ExPlatTest.kt
@@ -23,12 +23,10 @@ import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
-import org.wordpress.android.fluxc.store.ExperimentStore
 
 @ExperimentalCoroutinesApi
 class ExPlatTest {
     private val platform = "wpandroid"
-    private val experimentStore: ExperimentStore = mock()
     private val cache: FileBasedCache = mock()
     private val restClient: ExperimentRestClient = mock()
     private val logger: ExperimentLogger = mock()
@@ -183,14 +181,16 @@ class ExPlatTest {
     fun `forceRefresh does not interact with store if experiments is empty`() = runBlockingTest {
         exPlat.forceRefresh()
 
-        verifyNoInteractions(experimentStore)
+        verifyNoInteractions(restClient)
+        verifyNoInteractions(cache)
     }
 
     @Test
     fun `refreshIfNeeded does not interact with store if experiments is empty`() = runBlockingTest {
         exPlat.refreshIfNeeded()
 
-        verifyNoInteractions(experimentStore)
+        verifyNoInteractions(restClient)
+        verifyNoInteractions(cache)
     }
 
     @Test
@@ -200,7 +200,8 @@ class ExPlatTest {
         } catch (e: IllegalArgumentException) {
             // Do nothing.
         } finally {
-            verifyNoInteractions(experimentStore)
+            verifyNoInteractions(restClient)
+            verifyNoInteractions(cache)
         }
     }
 

--- a/experimentation/src/test/java/com/automattic/android/experimentation/ExPlatTest.kt
+++ b/experimentation/src/test/java/com/automattic/android/experimentation/ExPlatTest.kt
@@ -25,7 +25,6 @@ import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.store.ExperimentStore
 import org.wordpress.android.fluxc.store.ExperimentStore.Platform
-import org.wordpress.android.fluxc.utils.AppLogWrapper
 
 @ExperimentalCoroutinesApi
 class ExPlatTest {
@@ -33,7 +32,7 @@ class ExPlatTest {
     private val experimentStore: ExperimentStore = mock()
     private val cache: FileBasedCache = mock()
     private val restClient: ExperimentRestClient = mock()
-    private val appLogWrapper: AppLogWrapper = mock()
+    private val logger: ExperimentLogger = mock()
     private var exPlat: ExPlat = createExPlat(
         isDebug = false,
         experiments = emptySet(),
@@ -221,7 +220,7 @@ class ExPlatTest {
         ExPlat(
             platform = platform,
             experiments = experiments,
-            appLogWrapper = appLogWrapper,
+            logger = logger,
             coroutineScope = CoroutineScope(Dispatchers.Unconfined),
             isDebug = isDebug,
             cache = cache,

--- a/experimentation/src/test/java/com/automattic/android/experimentation/ExPlatTest.kt
+++ b/experimentation/src/test/java/com/automattic/android/experimentation/ExPlatTest.kt
@@ -24,11 +24,10 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
 import org.wordpress.android.fluxc.store.ExperimentStore
-import org.wordpress.android.fluxc.store.ExperimentStore.Platform
 
 @ExperimentalCoroutinesApi
 class ExPlatTest {
-    private val platform = Platform.WORDPRESS_ANDROID
+    private val platform = "wpandroid"
     private val experimentStore: ExperimentStore = mock()
     private val cache: FileBasedCache = mock()
     private val restClient: ExperimentRestClient = mock()
@@ -51,7 +50,7 @@ class ExPlatTest {
 
         exPlat.refreshIfNeeded()
 
-        verify(restClient, times(1)).fetchAssignments(eq(platform.value), any(), anyOrNull())
+        verify(restClient, times(1)).fetchAssignments(eq(platform), any(), anyOrNull())
     }
 
     @Test
@@ -64,7 +63,7 @@ class ExPlatTest {
 
         exPlat.refreshIfNeeded()
 
-        verify(restClient, times(1)).fetchAssignments(eq(platform.value), any(), anyOrNull())
+        verify(restClient, times(1)).fetchAssignments(eq(platform), any(), anyOrNull())
     }
 
     @Test
@@ -73,7 +72,7 @@ class ExPlatTest {
 
         exPlat.refreshIfNeeded()
 
-        verify(restClient, never()).fetchAssignments(eq(platform.value), any(), anyOrNull())
+        verify(restClient, never()).fetchAssignments(eq(platform), any(), anyOrNull())
     }
 
     @Test
@@ -86,7 +85,7 @@ class ExPlatTest {
 
         exPlat.forceRefresh()
 
-        verify(restClient, times(1)).fetchAssignments(eq(platform.value), any(), anyOrNull())
+        verify(restClient, times(1)).fetchAssignments(eq(platform), any(), anyOrNull())
     }
 
     @Test
@@ -106,7 +105,7 @@ class ExPlatTest {
 
         exPlat.getVariation(dummyExperiment, shouldRefreshIfStale = true)
 
-        verify(restClient, times(1)).fetchAssignments(eq(platform.value), any(), anyOrNull())
+        verify(restClient, times(1)).fetchAssignments(eq(platform), any(), anyOrNull())
     }
 
     @Test
@@ -119,7 +118,7 @@ class ExPlatTest {
 
         exPlat.getVariation(dummyExperiment, shouldRefreshIfStale = true)
 
-        verify(restClient, times(1)).fetchAssignments(eq(platform.value), any(), anyOrNull())
+        verify(restClient, times(1)).fetchAssignments(eq(platform), any(), anyOrNull())
     }
 
     @Test
@@ -128,7 +127,7 @@ class ExPlatTest {
 
         exPlat.getVariation(dummyExperiment, shouldRefreshIfStale = true)
 
-        verify(restClient, never()).fetchAssignments(eq(platform.value), any(), anyOrNull())
+        verify(restClient, never()).fetchAssignments(eq(platform), any(), anyOrNull())
     }
 
     @Test
@@ -137,7 +136,7 @@ class ExPlatTest {
 
         exPlat.getVariation(dummyExperiment, shouldRefreshIfStale = false)
 
-        verify(restClient, never()).fetchAssignments(eq(platform.value), any(), anyOrNull())
+        verify(restClient, never()).fetchAssignments(eq(platform), any(), anyOrNull())
     }
 
     @Test
@@ -146,7 +145,7 @@ class ExPlatTest {
 
         exPlat.getVariation(dummyExperiment, shouldRefreshIfStale = false)
 
-        verify(restClient, never()).fetchAssignments(eq(platform.value), any(), anyOrNull())
+        verify(restClient, never()).fetchAssignments(eq(platform), any(), anyOrNull())
     }
 
     @Test
@@ -177,7 +176,7 @@ class ExPlatTest {
         )
         exPlat.forceRefresh()
 
-        verify(restClient, times(1)).fetchAssignments(eq(platform.value), any(), anyOrNull())
+        verify(restClient, times(1)).fetchAssignments(eq(platform), any(), anyOrNull())
     }
 
     @Test
@@ -230,7 +229,7 @@ class ExPlatTest {
 
     private suspend fun setupAssignments(cachedAssignments: Assignments?, fetchedAssignments: Assignments) {
         whenever(cache.getAssignments()).thenReturn(cachedAssignments)
-        whenever(restClient.fetchAssignments(eq(platform.value), any(), anyOrNull()))
+        whenever(restClient.fetchAssignments(eq(platform), any(), anyOrNull()))
             .thenReturn(Result.success(fetchedAssignments))
     }
 

--- a/experimentation/src/test/java/com/automattic/android/experimentation/local/FileBasedCacheTest.kt
+++ b/experimentation/src/test/java/com/automattic/android/experimentation/local/FileBasedCacheTest.kt
@@ -59,7 +59,7 @@ internal class FileBasedCacheTest {
                 "experiment1" to Control,
                 "experiment2" to Treatment("variation2"),
             ),
-            ttl = 3600,
+            timeToLive = 3600,
             fetchedAt = 123456789L,
         )
     }

--- a/experimentation/src/test/java/com/automattic/android/experimentation/remote/AssignmentsDtoMapperTest.kt
+++ b/experimentation/src/test/java/com/automattic/android/experimentation/remote/AssignmentsDtoMapperTest.kt
@@ -27,7 +27,7 @@ class AssignmentsDtoMapperTest {
                 "experiment2" to Control,
                 "experiment3" to Control,
             ),
-            ttl = ttl,
+            timeToLive = ttl,
             fetchedAt = fetchedAt,
         )
 

--- a/experimentation/src/test/java/com/automattic/android/experimentation/remote/ExperimentRestClientTest.kt
+++ b/experimentation/src/test/java/com/automattic/android/experimentation/remote/ExperimentRestClientTest.kt
@@ -35,7 +35,7 @@ internal class ExperimentRestClientTest {
                     "experiment1" to Treatment("variation1"),
                     "experiment2" to Treatment("variation2"),
                 ),
-                ttl = 3600,
+                timeToLive = 3600,
                 fetchedAt = TEST_TIMESTAMP,
             ),
         )


### PR DESCRIPTION
### Description 

This PR replaces usage of `ExperimentsStore` from FluxC, with internal implementation of `AssignmentsRepository` that fetches data from remote, saves it to cache and offer it later.

I aimed for a minimal set of changes here, to not shadow that the logic remains unchanged here.

### How to test

Unit tests are passing after the change. But as they're heavily mocked, we can't really be sure that this caught all possible regressions: https://github.com/Automattic/Automattic-Tracks-Android/pull/239#discussion_r1732906646

Still, this is some safety net. To test this manually, please see #241 