### PR TITLE
Support passing `anon_id` to ExPlat

### DIFF
--- a/experimentation/src/main/java/com/automattic/android/experimentation/ExPlat.kt
+++ b/experimentation/src/main/java/com/automattic/android/experimentation/ExPlat.kt
@@ -24,11 +24,11 @@ class ExPlat internal constructor(
     private val activeVariations = mutableMapOf<String, Variation>()
     private val experimentIdentifiers: List<String> = experiments.map { it.identifier }
 
-    private var anonId: String? = null
+    private var anonymousId: String? = null
 
-    fun configure(anonId: String? = null) {
+    fun configure(anonymousId: String? = null) {
         clear()
-        this.anonId = anonId
+        this.anonymousId = anonymousId
     }
 
     /**
@@ -76,7 +76,7 @@ class ExPlat internal constructor(
     fun clear() {
         logger.d("ExPlat: clearing cached assignments and active variations")
         activeVariations.clear()
-        anonId = null
+        anonymousId = null
         coroutineScope.launch {
             repository.clear()
         }
@@ -103,7 +103,7 @@ class ExPlat internal constructor(
     }
 
     private suspend fun fetchAssignments() =
-        repository.fetch(platform, experimentIdentifiers, anonId).fold(
+        repository.fetch(platform, experimentIdentifiers, anonymousId).fold(
             onSuccess = {
                 logger.d("ExPlat: fetching assignments successful with result: $it")
             },

--- a/experimentation/src/main/java/com/automattic/android/experimentation/ExPlat.kt
+++ b/experimentation/src/main/java/com/automattic/android/experimentation/ExPlat.kt
@@ -24,6 +24,13 @@ class ExPlat internal constructor(
     private val activeVariations = mutableMapOf<String, Variation>()
     private val experimentIdentifiers: List<String> = experiments.map { it.identifier }
 
+    private var anonId: String? = null
+
+    fun configure(anonId: String? = null) {
+        clear()
+        this.anonId = anonId
+    }
+
     /**
      * This returns the current active [Variation] for the provided [Experiment].
      *
@@ -69,6 +76,7 @@ class ExPlat internal constructor(
     fun clear() {
         logger.d("ExPlat: clearing cached assignments and active variations")
         activeVariations.clear()
+        anonId = null
         coroutineScope.launch {
             repository.clear()
         }
@@ -95,7 +103,7 @@ class ExPlat internal constructor(
     }
 
     private suspend fun fetchAssignments() =
-        repository.fetch(platform, experimentIdentifiers).fold(
+        repository.fetch(platform, experimentIdentifiers, anonId).fold(
             onSuccess = {
                 logger.d("ExPlat: fetching assignments successful with result: $it")
             },

--- a/experimentation/src/main/java/com/automattic/android/experimentation/remote/UrlBuilder.kt
+++ b/experimentation/src/main/java/com/automattic/android/experimentation/remote/UrlBuilder.kt
@@ -27,7 +27,9 @@ internal class ExPlatUrlBuilder : UrlBuilder {
             .addPathSegment(platform)
             .apply {
                 experimentNames.forEach { addQueryParameter("experiment_names", it) }
-                addQueryParameter("anon_id", anonymousId.orEmpty())
+                anonymousId?.let {
+                    addQueryParameter("anon_id", it)
+                }
             }
             .build()
     }

--- a/experimentation/src/main/java/com/automattic/android/experimentation/remote/UrlBuilder.kt
+++ b/experimentation/src/main/java/com/automattic/android/experimentation/remote/UrlBuilder.kt
@@ -27,9 +27,7 @@ internal class ExPlatUrlBuilder : UrlBuilder {
             .addPathSegment(platform)
             .apply {
                 experimentNames.forEach { addQueryParameter("experiment_names", it) }
-                anonymousId?.let {
-                    addQueryParameter("anon_id", it)
-                }
+                anonymousId?.let { addQueryParameter("anon_id", it) }
             }
             .build()
     }

--- a/experimentation/src/test/java/com/automattic/android/experimentation/local/FileBasedCacheTest.kt
+++ b/experimentation/src/test/java/com/automattic/android/experimentation/local/FileBasedCacheTest.kt
@@ -50,6 +50,13 @@ internal class FileBasedCacheTest {
         assertNull(result)
     }
 
+    @Test
+    fun `clearing empty cache has no effect`() = runTest {
+        val sut = fileBasedCache()
+
+        sut.clear()
+    }
+
     private fun fileBasedCache() =
         FileBasedCache(cacheDir = createTempDirectory().toFile())
 

--- a/experimentation/src/test/java/com/automattic/android/experimentation/remote/MockWebServerUrlBuilder.kt
+++ b/experimentation/src/test/java/com/automattic/android/experimentation/remote/MockWebServerUrlBuilder.kt
@@ -1,0 +1,25 @@
+package com.automattic.android.experimentation.remote
+
+import okhttp3.HttpUrl
+import okhttp3.mockwebserver.MockWebServer
+
+internal class MockWebServerUrlBuilder(
+    private val exPlatUrlBuilder: ExPlatUrlBuilder,
+    private val server: MockWebServer,
+) : UrlBuilder {
+    override fun buildUrl(
+        platform: String,
+        experimentNames: List<String>,
+        anonymousId: String?,
+    ): HttpUrl {
+        return exPlatUrlBuilder.buildUrl(
+            platform,
+            experimentNames,
+            anonymousId,
+        ).newBuilder()
+            .scheme("http")
+            .host(server.url("/").host)
+            .port(server.url("/").port)
+            .build()
+    }
+}


### PR DESCRIPTION
Preferably, review:
- #239 

first.

### Description

Passing `anon_id` query parameter seems like a necessity for a part (all?) of the experiments.

I keep this nullable and not mandatory to align to iOS counterpart 

https://github.com/Automattic/Automattic-Tracks-iOS/blob/ccf6b7d7424e32857819d35aa54813875557f5c8/Sources/Experiments/ExPlatService.swift#L11


### Testing

Automated tests are introduced that reflect necessity of `anon_id` for some experiments. Further e2e manual testing is available with example app in #241 
