### PR TITLE
Improve threading and test suite

### DIFF
--- a/experimentation/build.gradle
+++ b/experimentation/build.gradle
@@ -49,9 +49,6 @@ dependencies {
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$kotlinxCoroutinesVersion"
     testImplementation "junit:junit:$junitVersion"
     testImplementation "org.assertj:assertj-core:$assertjVersion"
-    testImplementation "org.mockito.kotlin:mockito-kotlin:$mockitoKotlinVersion"
-    testImplementation "org.mockito:mockito-inline:$mockitoInlineVersion"
-
     testImplementation "com.squareup.okhttp3:mockwebserver:$okHttp"
 }
 

--- a/experimentation/src/main/java/com/automattic/android/experimentation/ExPlat.kt
+++ b/experimentation/src/main/java/com/automattic/android/experimentation/ExPlat.kt
@@ -48,7 +48,7 @@ class ExPlat internal constructor(
      * If the provided [Experiment] was not included in [experiments], then [Control] is returned.
      * If [isDebug] is `true`, an [IllegalArgumentException] is thrown instead.
      */
-    fun getVariation(experiment: Experiment): Variation? {
+    fun getVariation(experiment: Experiment): Variation {
         val experimentIdentifier = experiment.identifier
         if (!experimentIdentifiers.contains(experimentIdentifier)) {
             val message = "ExPlat: experiment not found: \"${experimentIdentifier}\"! " +

--- a/experimentation/src/main/java/com/automattic/android/experimentation/ExPlat.kt
+++ b/experimentation/src/main/java/com/automattic/android/experimentation/ExPlat.kt
@@ -48,10 +48,7 @@ class ExPlat internal constructor(
      * If the provided [Experiment] was not included in [experiments], then [Control] is returned.
      * If [isDebug] is `true`, an [IllegalArgumentException] is thrown instead.
      */
-    fun getVariation(
-        experiment: Experiment,
-        shouldRefreshIfStale: Boolean = false,
-    ): Variation {
+    fun getVariation(experiment: Experiment): Variation {
         val experimentIdentifier = experiment.identifier
         if (!experimentIdentifiers.contains(experimentIdentifier)) {
             val message = "ExPlat: experiment not found: \"${experimentIdentifier}\"! " +
@@ -65,7 +62,7 @@ class ExPlat internal constructor(
             }
         }
         return activeVariations.getOrPut(experimentIdentifier) {
-            getAssignments(if (shouldRefreshIfStale) IF_STALE else NEVER)
+            getAssignments(NEVER)
                 .variations[experimentIdentifier] ?: Control
         }
     }

--- a/experimentation/src/main/java/com/automattic/android/experimentation/ExPlat.kt
+++ b/experimentation/src/main/java/com/automattic/android/experimentation/ExPlat.kt
@@ -48,7 +48,7 @@ class ExPlat internal constructor(
      * If the provided [Experiment] was not included in [experiments], then [Control] is returned.
      * If [isDebug] is `true`, an [IllegalArgumentException] is thrown instead.
      */
-    fun getVariation(experiment: Experiment): Variation {
+    fun getVariation(experiment: Experiment): Variation? {
         val experimentIdentifier = experiment.identifier
         if (!experimentIdentifiers.contains(experimentIdentifier)) {
             val message = "ExPlat: experiment not found: \"${experimentIdentifier}\"! " +
@@ -62,8 +62,7 @@ class ExPlat internal constructor(
             }
         }
         return activeVariations.getOrPut(experimentIdentifier) {
-            getAssignments(NEVER)
-                .variations[experimentIdentifier] ?: Control
+            getAssignments(NEVER)?.variations?.get(experimentIdentifier) ?: Control
         }
     }
 
@@ -88,9 +87,10 @@ class ExPlat internal constructor(
         }
     }
 
-    private fun getAssignments(refreshStrategy: RefreshStrategy): Assignments {
-        val cachedAssignments: Assignments = repository.getCached() ?: Assignments(emptyMap(), 0, -1)
+    private fun getAssignments(refreshStrategy: RefreshStrategy): Assignments? {
+        val cachedAssignments: Assignments? = repository.getCached()
         if (refreshStrategy == ALWAYS ||
+            cachedAssignments == null ||
             (refreshStrategy == IF_STALE && assignmentsValidator.isStale(cachedAssignments))
         ) {
             coroutineScope.launch { fetchAssignments() }

--- a/experimentation/src/main/java/com/automattic/android/experimentation/remote/ExperimentRestClient.kt
+++ b/experimentation/src/main/java/com/automattic/android/experimentation/remote/ExperimentRestClient.kt
@@ -5,7 +5,7 @@ import com.automattic.android.experimentation.domain.Clock
 import com.automattic.android.experimentation.domain.SystemClock
 import com.automattic.android.experimentation.remote.AssignmentsDtoMapper.toAssignments
 import com.squareup.moshi.Moshi
-import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
 import okhttp3.OkHttpClient
 import okhttp3.Request
@@ -17,6 +17,7 @@ internal class ExperimentRestClient(
     private val jsonAdapter: AssignmentsDtoJsonAdapter = AssignmentsDtoJsonAdapter(moshi),
     private val urlBuilder: UrlBuilder = ExPlatUrlBuilder(),
     private val clock: Clock = SystemClock(),
+    private val dispatcher: CoroutineDispatcher,
 ) {
 
     suspend fun fetchAssignments(
@@ -31,7 +32,7 @@ internal class ExperimentRestClient(
             .get()
             .build()
 
-        return withContext(Dispatchers.IO) {
+        return withContext(dispatcher) {
             okHttpClient.newCall(request).execute().use { response ->
                 if (!response.isSuccessful) {
                     Result.failure(IOException("Unexpected code $response"))

--- a/experimentation/src/main/java/com/automattic/android/experimentation/repository/AssignmentsRepository.kt
+++ b/experimentation/src/main/java/com/automattic/android/experimentation/repository/AssignmentsRepository.kt
@@ -28,8 +28,8 @@ internal class AssignmentsRepository(
         )
     }
 
-    suspend fun getCached(): Assignments? {
-        return cache.getAssignments()
+    fun getCached(): Assignments? {
+        return cache.latest
     }
 
     suspend fun clear() {

--- a/experimentation/src/test/java/com/automattic/android/experimentation/ExPlatTest.kt
+++ b/experimentation/src/test/java/com/automattic/android/experimentation/ExPlatTest.kt
@@ -11,7 +11,6 @@ import com.automattic.android.experimentation.remote.ExPlatUrlBuilder
 import com.automattic.android.experimentation.remote.ExperimentRestClient
 import com.automattic.android.experimentation.remote.MockWebServerUrlBuilder
 import com.automattic.android.experimentation.repository.AssignmentsRepository
-import kotlin.io.path.createTempDirectory
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestScope
@@ -22,6 +21,7 @@ import okhttp3.mockwebserver.MockWebServer
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.Test
+import kotlin.io.path.createTempDirectory
 
 @ExperimentalCoroutinesApi
 internal class ExPlatTest {
@@ -105,8 +105,9 @@ internal class ExPlatTest {
             val exPlat = createExPlat(clock = { 123 })
             tempCache.saveAssignments(
                 testAssignment.copy(
-                    mapOf(testExperimentName to Control), fetchedAt = 0
-                )
+                    mapOf(testExperimentName to Control),
+                    fetchedAt = 0,
+                ),
             )
             val firstGet = exPlat.getVariation(testExperiment)
             exPlat.forceRefresh()
@@ -156,7 +157,7 @@ internal class ExPlatTest {
         tempCache = FileBasedCache(
             createTempDirectory().toFile(),
             dispatcher = dispatcher,
-            scope = coroutineScope
+            scope = coroutineScope,
         )
 
         return ExPlat(

--- a/experimentation/src/test/java/com/automattic/android/experimentation/ExPlatTest.kt
+++ b/experimentation/src/test/java/com/automattic/android/experimentation/ExPlatTest.kt
@@ -27,11 +27,6 @@ import org.junit.Test
 internal class ExPlatTest {
     private val server: MockWebServer = MockWebServer()
     private val platform = "wpandroid"
-    private val testExperimentName = "testExperiment"
-    private val testVariationName = "testVariation"
-    private val testExperiment = object : Experiment {
-        override val identifier: String = testExperimentName
-    }
     private lateinit var tempCache: FileBasedCache
 
     @Test
@@ -135,6 +130,18 @@ internal class ExPlatTest {
             .hasMessageContaining("experiment not found")
     }
 
+    private val testExperimentName = "testExperiment"
+    private val testVariationName = "testVariation"
+    private val testExperiment = object : Experiment {
+        override val identifier: String = testExperimentName
+    }
+    private val testVariation = Treatment(testVariationName)
+    private val testAssignment = Assignments(
+        variations = mapOf(testExperimentName to testVariation),
+        timeToLive = 3600,
+        fetchedAt = 0L,
+    )
+
     private fun TestScope.createExPlat(
         clock: Clock = Clock { 0 },
         experiments: Set<Experiment> = setOf(testExperiment),
@@ -165,13 +172,6 @@ internal class ExPlatTest {
             repository = AssignmentsRepository(restClient, tempCache),
         )
     }
-
-    private val testVariation = Treatment(testVariationName)
-    private val testAssignment = Assignments(
-        variations = mapOf(testExperimentName to testVariation),
-        timeToLive = 3600,
-        fetchedAt = 0L,
-    )
 
     private fun enqueueSuccessfulNetworkResponse(variation: Variation = testVariation) {
         val variationName = when (variation) {

--- a/experimentation/src/test/java/com/automattic/android/experimentation/ExPlatTest.kt
+++ b/experimentation/src/test/java/com/automattic/android/experimentation/ExPlatTest.kt
@@ -105,10 +105,14 @@ internal class ExPlatTest {
     }
 
     @Test
-    fun `clear calls experiment store`() = runBlockingTest {
-        exPlat.clear()
+    fun `clearing removes cached data`() = runTest {
+        val exPlat = createExPlat()
+        tempCache.saveAssignments(testAssignment)
 
-        verify(cache, times(1)).clear()
+        exPlat.clear()
+        runCurrent()
+
+        assertThat(tempCache.latest).isNull()
     }
 
     @Test

--- a/experimentation/src/test/java/com/automattic/android/experimentation/ExPlatTest.kt
+++ b/experimentation/src/test/java/com/automattic/android/experimentation/ExPlatTest.kt
@@ -105,20 +105,6 @@ internal class ExPlatTest {
     }
 
     @Test
-    fun `force refresh is successful when cache is fresh `() = runBlockingTest {
-        exPlat = createExPlat(
-            isDebug = true,
-            experiments = setOf(dummyExperiment),
-        )
-        val fetchedAssignments = buildAssignments()
-        setupAssignments(cachedAssignments = buildAssignments(isStale = true), fetchedAssignments = fetchedAssignments)
-
-        exPlat.forceRefresh()
-
-        verify(cache).saveAssignments(fetchedAssignments)
-    }
-
-    @Test
     fun `clear calls experiment store`() = runBlockingTest {
         exPlat.clear()
 

--- a/experimentation/src/test/java/com/automattic/android/experimentation/ExPlatTest.kt
+++ b/experimentation/src/test/java/com/automattic/android/experimentation/ExPlatTest.kt
@@ -93,12 +93,27 @@ internal class ExPlatTest {
     }
 
     @Test
-    fun `refreshIfNeeded does not fetch assignments if cache is fresh`() = runBlockingTest {
-        setupAssignments(cachedAssignments = buildAssignments(isStale = false), fetchedAssignments = buildAssignments())
+    fun `refreshing in case of fresh cache is not fetching new assignments`() = runTest {
+        enqueueNetworkResponse(Treatment("variation1"))
+        val exPlat = createExPlat(this, clock = { 3599 })
+        tempCache.saveAssignments(
+            Assignments(
+                variations = mapOf("dummy" to Treatment("variation1")),
+                timeToLive = 3600,
+                fetchedAt = 0L,
+            ),
+        )
 
         exPlat.refreshIfNeeded()
+        runCurrent()
 
-        verify(restClient, never()).fetchAssignments(eq(platform), any(), anyOrNull())
+        assertThat(tempCache.latest).isEqualTo(
+            Assignments(
+                variations = mapOf("dummy" to Treatment("variation1")),
+                timeToLive = 3600,
+                fetchedAt = 0L,
+            ),
+        )
     }
 
     @Test

--- a/experimentation/src/test/java/com/automattic/android/experimentation/ExPlatTest.kt
+++ b/experimentation/src/test/java/com/automattic/android/experimentation/ExPlatTest.kt
@@ -166,7 +166,7 @@ internal class ExPlatTest {
                 override fun d(message: String) = Unit
                 override fun e(message: String, throwable: Throwable) = Unit
             },
-            coroutineScope = coroutineScope.backgroundScope,
+            coroutineScope = coroutineScope,
             isDebug = true,
             assignmentsValidator = AssignmentsValidator(clock = clock),
             repository = AssignmentsRepository(restClient, tempCache),

--- a/experimentation/src/test/java/com/automattic/android/experimentation/ExPlatTest.kt
+++ b/experimentation/src/test/java/com/automattic/android/experimentation/ExPlatTest.kt
@@ -141,45 +141,6 @@ internal class ExPlatTest {
         assertThat(secondGet).isEqualTo(firstGet).isEqualTo(Control)
     }
 
-    @Test
-    fun `forceRefresh fetches assignments if experiments is not empty`() = runBlockingTest {
-        exPlat = createExPlat(
-            isDebug = true,
-            experiments = setOf(dummyExperiment),
-        )
-        exPlat.forceRefresh()
-
-        verify(restClient, times(1)).fetchAssignments(eq(platform), any(), anyOrNull())
-    }
-
-    @Test
-    fun `forceRefresh does not interact with store if experiments is empty`() = runBlockingTest {
-        exPlat.forceRefresh()
-
-        verifyNoInteractions(restClient)
-        verifyNoInteractions(cache)
-    }
-
-    @Test
-    fun `refreshIfNeeded does not interact with store if experiments is empty`() = runBlockingTest {
-        exPlat.refreshIfNeeded()
-
-        verifyNoInteractions(restClient)
-        verifyNoInteractions(cache)
-    }
-
-    @Test
-    fun `getVariation does not interact with store if experiments is empty`() = runBlockingTest {
-        try {
-            exPlat.getVariation(dummyExperiment)
-        } catch (e: IllegalArgumentException) {
-            // Do nothing.
-        } finally {
-            verifyNoInteractions(restClient)
-            verifyNoInteractions(cache)
-        }
-    }
-
     @Test(expected = IllegalArgumentException::class)
     fun `getVariation throws IllegalArgumentException if experiment was not found and is debug`() {
         runBlockingTest {

--- a/experimentation/src/test/java/com/automattic/android/experimentation/ExPlatTest.kt
+++ b/experimentation/src/test/java/com/automattic/android/experimentation/ExPlatTest.kt
@@ -121,25 +121,27 @@ internal class ExPlatTest {
     as it could lead to unexpected behavior.
      */
     @Test
-    fun `getting variation for the second time returns the same value, even if cache was updated`() = runTest {
-        enqueueSuccessfulNetworkResponse(variation = Treatment("variation2"))
-        val exPlat = createExPlat(clock = { 123 })
-        tempCache.saveAssignments(
-            testAssignment.copy(
-                mapOf(testExperimentName to Control), fetchedAt = 0
+    fun `getting variation for the second time returns the same value, even if cache was updated`() =
+        runTest {
+            enqueueSuccessfulNetworkResponse(variation = Treatment("variation2"))
+            val exPlat = createExPlat(clock = { 123 })
+            tempCache.saveAssignments(
+                testAssignment.copy(
+                    mapOf(testExperimentName to Control), fetchedAt = 0
+                )
             )
-        )
-        val firstGet = exPlat.getVariation(dummyExperiment)
-        exPlat.forceRefresh()
-        runCurrent()
+            val firstGet = exPlat.getVariation(dummyExperiment)
+            exPlat.forceRefresh()
+            runCurrent()
 
-        val secondGet = exPlat.getVariation(dummyExperiment)
+            val secondGet = exPlat.getVariation(dummyExperiment)
 
-        // Even though the cache was updated...
-        assertThat(tempCache.latest!!.variations[testExperimentName]).isEqualTo(Treatment("variation2"))
-        // ...the second `get` should return the same value as the first one
-        assertThat(secondGet).isEqualTo(firstGet).isEqualTo(Control)
-    }
+            // Even though the cache was updated...
+            assertThat(tempCache.latest!!.variations[testExperimentName]).isEqualTo(Treatment("variation2"))
+            // ...the second `get` should return the same value as the first one
+            assertThat(secondGet).isEqualTo(firstGet).isEqualTo(Control)
+        }
+
 
     @Test(expected = IllegalArgumentException::class)
     fun `getVariation throws IllegalArgumentException if experiment was not found and is debug`() {
@@ -173,7 +175,11 @@ internal class ExPlatTest {
             dispatcher = dispatcher,
             clock = clock,
         )
-        tempCache = FileBasedCache(createTempDirectory().toFile(), dispatcher = dispatcher, scope = coroutineScope)
+        tempCache = FileBasedCache(
+            createTempDirectory().toFile(),
+            dispatcher = dispatcher,
+            scope = coroutineScope
+        )
 
         return ExPlat(
             platform = platform,
@@ -218,7 +224,10 @@ internal class ExPlatTest {
         )
     }
 
-    private suspend fun setupAssignments(cachedAssignments: Assignments?, fetchedAssignments: Assignments) {
+    private suspend fun setupAssignments(
+        cachedAssignments: Assignments?,
+        fetchedAssignments: Assignments
+    ) {
         whenever(cache.getAssignments()).thenReturn(cachedAssignments)
         whenever(restClient.fetchAssignments(eq(platform), any(), anyOrNull()))
             .thenReturn(Result.success(fetchedAssignments))

--- a/experimentation/src/test/java/com/automattic/android/experimentation/local/FileBasedCacheTest.kt
+++ b/experimentation/src/test/java/com/automattic/android/experimentation/local/FileBasedCacheTest.kt
@@ -62,7 +62,7 @@ internal class FileBasedCacheTest {
     private fun fileBasedCache(scope: TestScope) = FileBasedCache(
         cacheDir = createTempDirectory().toFile(),
         dispatcher = StandardTestDispatcher(scope.testScheduler),
-        scope = scope
+        scope = scope,
     )
 
     companion object {

--- a/experimentation/src/test/java/com/automattic/android/experimentation/local/FileBasedCacheTest.kt
+++ b/experimentation/src/test/java/com/automattic/android/experimentation/local/FileBasedCacheTest.kt
@@ -4,6 +4,8 @@ import com.automattic.android.experimentation.domain.Assignments
 import com.automattic.android.experimentation.domain.Variation.Control
 import com.automattic.android.experimentation.domain.Variation.Treatment
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
@@ -15,7 +17,7 @@ internal class FileBasedCacheTest {
 
     @Test
     fun `saving and reading assignments is successful`() = runTest {
-        val sut = fileBasedCache()
+        val sut = fileBasedCache(this)
         sut.saveAssignments(TEST_ASSIGNMENTS)
 
         val result = sut.getAssignments()
@@ -25,7 +27,7 @@ internal class FileBasedCacheTest {
 
     @Test
     fun `updating assignments is successful`() = runTest {
-        val sut = fileBasedCache()
+        val sut = fileBasedCache(this)
         val updatedTestAssignments = TEST_ASSIGNMENTS.copy(
             variations = mapOf(
                 "experiment1" to Treatment("variation1"),
@@ -43,7 +45,7 @@ internal class FileBasedCacheTest {
 
     @Test
     fun `getting assignments from empty cache returns no results`() = runTest {
-        val sut = fileBasedCache()
+        val sut = fileBasedCache(this)
 
         val result = sut.getAssignments()
 
@@ -52,13 +54,13 @@ internal class FileBasedCacheTest {
 
     @Test
     fun `clearing empty cache has no effect`() = runTest {
-        val sut = fileBasedCache()
+        val sut = fileBasedCache(this)
 
         sut.clear()
     }
 
-    private fun fileBasedCache() =
-        FileBasedCache(cacheDir = createTempDirectory().toFile())
+    private fun fileBasedCache(scope: TestScope) =
+        FileBasedCache(cacheDir = createTempDirectory().toFile(), dispatcher = StandardTestDispatcher(scope.testScheduler), scope = scope)
 
     companion object {
         private val TEST_ASSIGNMENTS = Assignments(

--- a/experimentation/src/test/java/com/automattic/android/experimentation/local/FileBasedCacheTest.kt
+++ b/experimentation/src/test/java/com/automattic/android/experimentation/local/FileBasedCacheTest.kt
@@ -59,8 +59,11 @@ internal class FileBasedCacheTest {
         sut.clear()
     }
 
-    private fun fileBasedCache(scope: TestScope) =
-        FileBasedCache(cacheDir = createTempDirectory().toFile(), dispatcher = StandardTestDispatcher(scope.testScheduler), scope = scope)
+    private fun fileBasedCache(scope: TestScope) = FileBasedCache(
+        cacheDir = createTempDirectory().toFile(),
+        dispatcher = StandardTestDispatcher(scope.testScheduler),
+        scope = scope
+    )
 
     companion object {
         private val TEST_ASSIGNMENTS = Assignments(

--- a/experimentation/src/test/java/com/automattic/android/experimentation/remote/ExperimentRestClientTest.kt
+++ b/experimentation/src/test/java/com/automattic/android/experimentation/remote/ExperimentRestClientTest.kt
@@ -5,6 +5,8 @@ package com.automattic.android.experimentation.remote
 import com.automattic.android.experimentation.domain.Assignments
 import com.automattic.android.experimentation.domain.Variation.Treatment
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
 import okhttp3.mockwebserver.Dispatcher
 import okhttp3.mockwebserver.MockResponse
@@ -13,24 +15,15 @@ import okhttp3.mockwebserver.RecordedRequest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
-import org.junit.Before
 import org.junit.Test
 
 internal class ExperimentRestClientTest {
 
     private val server: MockWebServer = MockWebServer()
-    private lateinit var sut: ExperimentRestClient
-
-    @Before
-    fun setUp() {
-        sut = ExperimentRestClient(
-            urlBuilder = MockWebServerUrlBuilder(ExPlatUrlBuilder(), server),
-            clock = { TEST_TIMESTAMP },
-        )
-    }
 
     @Test
     fun `fetching assignments from api is successful`() = runTest {
+        val sut = buildSut(this)
         server.enqueue(SUCCESSFUL_RESPONSE)
         val expectedResponse = Result.success(
             Assignments(
@@ -50,6 +43,7 @@ internal class ExperimentRestClientTest {
 
     @Test
     fun `fetching assignments from an unavailable api is a failure`() = runTest {
+        val sut = buildSut(this)
         val errorCode = 503
         server.enqueue(MockResponse().setResponseCode(errorCode))
 
@@ -61,6 +55,7 @@ internal class ExperimentRestClientTest {
 
     @Test
     fun `fetching assignments from an api with unexpected response is a failure`() = runTest {
+        val sut = buildSut(this)
         server.enqueue(MockResponse().setResponseCode(200).setBody("unexpected response"))
 
         val result = sut.fetchAssignments("", emptyList())
@@ -70,6 +65,7 @@ internal class ExperimentRestClientTest {
 
     @Test
     fun `fetching assignments from an api that requires anon id is successful`() = runTest {
+        val sut = buildSut(this)
         val respondOnlyOnAnonIdDispatcher = object : Dispatcher() {
             override fun dispatch(request: RecordedRequest): MockResponse {
                 return if (!request.requestUrl?.queryParameter("anon_id").isNullOrEmpty()) {
@@ -85,6 +81,12 @@ internal class ExperimentRestClientTest {
 
         assertThat(result.getOrNull()!!.variations).isNotEmpty
     }
+
+    private fun buildSut(scope: TestScope) = ExperimentRestClient(
+        urlBuilder = MockWebServerUrlBuilder(ExPlatUrlBuilder(), server),
+        clock = { TEST_TIMESTAMP },
+        dispatcher = StandardTestDispatcher(scope.testScheduler),
+    )
 
     companion object {
         private const val TEST_TIMESTAMP = 123456789L


### PR DESCRIPTION
### Description

This PR aims to:
- add some improvements to threading by removing `runBlocking` call in `getAssignments` method
- improve the test suite (https://github.com/Automattic/Automattic-Tracks-Android/pull/239#discussion_r1732906646)
- fix a quick in public API design of requesting cache refresh when getting assignments

### To test
This PR introduces a robust test suite. Still, you can perform some smoke tests if you'd like following instructions from #241  