### PR TITLE
Experiments public contract

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -30,10 +30,18 @@ steps:
       cp gradle.properties-example gradle.properties
       ./gradlew test
 
+  - label: "API verification"
+    key: "api"
+    plugins: [$CI_TOOLKIT]
+    command: |
+      cp gradle.properties-example gradle.properties
+      ./gradlew :experimentation:apiCheck
+
   - label: "Publish {{matrix}} to S3"
     depends_on:
       - "lint"
       - "test"
+      - "api""
     plugins: [$CI_TOOLKIT]
     matrix:
       - AutomatticTracks

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -41,7 +41,7 @@ steps:
     depends_on:
       - "lint"
       - "test"
-      - "api""
+      - "api"
     plugins: [$CI_TOOLKIT]
     matrix:
       - AutomatticTracks

--- a/experimentation/README.md
+++ b/experimentation/README.md
@@ -1,0 +1,63 @@
+# Experimentation
+
+## Introduction
+
+This module provides an SDK to communicate with Automattic-internal A/B testing service: ExPlat.
+
+## Coordinates
+
+```groovy
+dependencies {
+    implementation 'com.automattic.tracks:experimentation:{recent_release}'
+}
+```
+
+## Usage
+
+### Initialization
+
+```kotlin
+val experiments = setOf(
+    Experiment("experiment_1"),
+    Experiment("experiment_2")
+)
+
+// If injected in a DI container, the repository should be a singleton
+val repository: VariationsRepository = VariationsRepository.create(
+    experiments = experiments
+    /* see KDoc documentation for detailed description of parameters */
+)
+repository.configure(anonId = "currently_logged_in_user_id_or_random_uuid")
+```
+
+### Getting variation
+
+```kotlin
+// New variations will be available on the next application session. See KDoc for `VariationsRepository#getVariation`
+val variation = repository.getVariation("experiment_1")
+
+when (variation) {
+    is Control -> {
+        // continue with control group
+    }
+    is Treatment -> {
+        println("Treatment group: ${variation.value}")
+        // apply treatment changes
+    }
+}
+```
+
+### User logs out
+
+```kotlin
+repository.clean()
+```
+
+### Different user logs in
+
+```kotlin
+repository.configure(anonId = "new_user_id")
+```
+
+## Testing
+The SDK offers `VariantionsRepository` interface, which can be doubled in tests.

--- a/experimentation/api/experimentation.api
+++ b/experimentation/api/experimentation.api
@@ -1,0 +1,70 @@
+public final class com/automattic/android/experimentation/ExPlat : com/automattic/android/experimentation/VariationsRepository {
+	public fun clear ()V
+	public fun configure (Ljava/lang/String;)V
+	public fun getVariation (Lcom/automattic/android/experimentation/Experiment;)Lcom/automattic/android/experimentation/domain/Variation;
+	public fun refresh (Z)V
+}
+
+public abstract interface class com/automattic/android/experimentation/Experiment {
+	public abstract fun getIdentifier ()Ljava/lang/String;
+}
+
+public abstract interface class com/automattic/android/experimentation/ExperimentLogger {
+	public abstract fun d (Ljava/lang/String;)V
+	public abstract fun e (Ljava/lang/String;Ljava/lang/Throwable;)V
+}
+
+public abstract interface class com/automattic/android/experimentation/VariationsRepository {
+	public static final field Companion Lcom/automattic/android/experimentation/VariationsRepository$Companion;
+	public abstract fun clear ()V
+	public abstract fun configure (Ljava/lang/String;)V
+	public abstract fun getVariation (Lcom/automattic/android/experimentation/Experiment;)Lcom/automattic/android/experimentation/domain/Variation;
+	public abstract fun refresh (Z)V
+}
+
+public final class com/automattic/android/experimentation/VariationsRepository$Companion {
+	public final fun create (Ljava/lang/String;Ljava/util/Set;Lcom/automattic/android/experimentation/ExperimentLogger;Lkotlinx/coroutines/CoroutineScope;Lkotlinx/coroutines/CoroutineDispatcher;ZLjava/io/File;)Lcom/automattic/android/experimentation/ExPlat;
+	public static synthetic fun create$default (Lcom/automattic/android/experimentation/VariationsRepository$Companion;Ljava/lang/String;Ljava/util/Set;Lcom/automattic/android/experimentation/ExperimentLogger;Lkotlinx/coroutines/CoroutineScope;Lkotlinx/coroutines/CoroutineDispatcher;ZLjava/io/File;ILjava/lang/Object;)Lcom/automattic/android/experimentation/ExPlat;
+}
+
+public final class com/automattic/android/experimentation/VariationsRepository$DefaultImpls {
+	public static synthetic fun configure$default (Lcom/automattic/android/experimentation/VariationsRepository;Ljava/lang/String;ILjava/lang/Object;)V
+	public static synthetic fun refresh$default (Lcom/automattic/android/experimentation/VariationsRepository;ZILjava/lang/Object;)V
+}
+
+public final class com/automattic/android/experimentation/domain/Assignments {
+	public fun <init> (Ljava/util/Map;IJ)V
+	public final fun component1 ()Ljava/util/Map;
+	public final fun component2 ()I
+	public final fun component3 ()J
+	public final fun copy (Ljava/util/Map;IJ)Lcom/automattic/android/experimentation/domain/Assignments;
+	public static synthetic fun copy$default (Lcom/automattic/android/experimentation/domain/Assignments;Ljava/util/Map;IJILjava/lang/Object;)Lcom/automattic/android/experimentation/domain/Assignments;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFetchedAt ()J
+	public final fun getTimeToLive ()I
+	public final fun getVariations ()Ljava/util/Map;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class com/automattic/android/experimentation/domain/Variation {
+}
+
+public final class com/automattic/android/experimentation/domain/Variation$Control : com/automattic/android/experimentation/domain/Variation {
+	public static final field INSTANCE Lcom/automattic/android/experimentation/domain/Variation$Control;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/automattic/android/experimentation/domain/Variation$Treatment : com/automattic/android/experimentation/domain/Variation {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lcom/automattic/android/experimentation/domain/Variation$Treatment;
+	public static synthetic fun copy$default (Lcom/automattic/android/experimentation/domain/Variation$Treatment;Ljava/lang/String;ILjava/lang/Object;)Lcom/automattic/android/experimentation/domain/Variation$Treatment;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getName ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+

--- a/experimentation/api/experimentation.api
+++ b/experimentation/api/experimentation.api
@@ -1,12 +1,22 @@
 public final class com/automattic/android/experimentation/ExPlat : com/automattic/android/experimentation/VariationsRepository {
 	public fun clear ()V
 	public fun configure (Ljava/lang/String;)V
-	public fun getVariation (Lcom/automattic/android/experimentation/Experiment;)Lcom/automattic/android/experimentation/domain/Variation;
+	public fun getVariation-98D7FEw (Ljava/lang/String;)Lcom/automattic/android/experimentation/domain/Variation;
 	public fun refresh (Z)V
 }
 
-public abstract interface class com/automattic/android/experimentation/Experiment {
-	public abstract fun getIdentifier ()Ljava/lang/String;
+public final class com/automattic/android/experimentation/Experiment {
+	public static final synthetic fun box-impl (Ljava/lang/String;)Lcom/automattic/android/experimentation/Experiment;
+	public static fun constructor-impl (Ljava/lang/String;)Ljava/lang/String;
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun equals-impl (Ljava/lang/String;Ljava/lang/Object;)Z
+	public static final fun equals-impl0 (Ljava/lang/String;Ljava/lang/String;)Z
+	public final fun getIdentifier ()Ljava/lang/String;
+	public fun hashCode ()I
+	public static fun hashCode-impl (Ljava/lang/String;)I
+	public fun toString ()Ljava/lang/String;
+	public static fun toString-impl (Ljava/lang/String;)Ljava/lang/String;
+	public final synthetic fun unbox-impl ()Ljava/lang/String;
 }
 
 public abstract interface class com/automattic/android/experimentation/ExperimentLogger {
@@ -18,7 +28,7 @@ public abstract interface class com/automattic/android/experimentation/Variation
 	public static final field Companion Lcom/automattic/android/experimentation/VariationsRepository$Companion;
 	public abstract fun clear ()V
 	public abstract fun configure (Ljava/lang/String;)V
-	public abstract fun getVariation (Lcom/automattic/android/experimentation/Experiment;)Lcom/automattic/android/experimentation/domain/Variation;
+	public abstract fun getVariation-98D7FEw (Ljava/lang/String;)Lcom/automattic/android/experimentation/domain/Variation;
 	public abstract fun refresh (Z)V
 }
 

--- a/experimentation/api/experimentation.api
+++ b/experimentation/api/experimentation.api
@@ -1,8 +1,7 @@
 public final class com/automattic/android/experimentation/ExPlat : com/automattic/android/experimentation/VariationsRepository {
 	public fun clear ()V
-	public fun configure (Ljava/lang/String;)V
 	public fun getVariation-98D7FEw (Ljava/lang/String;)Lcom/automattic/android/experimentation/domain/Variation;
-	public fun refresh (Z)V
+	public fun initialize (Ljava/lang/String;)V
 }
 
 public final class com/automattic/android/experimentation/Experiment {
@@ -24,37 +23,20 @@ public abstract interface class com/automattic/android/experimentation/Experimen
 	public abstract fun e (Ljava/lang/String;Ljava/lang/Throwable;)V
 }
 
+public final class com/automattic/android/experimentation/ExperimentLogger$DefaultImpls {
+	public static synthetic fun e$default (Lcom/automattic/android/experimentation/ExperimentLogger;Ljava/lang/String;Ljava/lang/Throwable;ILjava/lang/Object;)V
+}
+
 public abstract interface class com/automattic/android/experimentation/VariationsRepository {
 	public static final field Companion Lcom/automattic/android/experimentation/VariationsRepository$Companion;
 	public abstract fun clear ()V
-	public abstract fun configure (Ljava/lang/String;)V
 	public abstract fun getVariation-98D7FEw (Ljava/lang/String;)Lcom/automattic/android/experimentation/domain/Variation;
-	public abstract fun refresh (Z)V
+	public abstract fun initialize (Ljava/lang/String;)V
 }
 
 public final class com/automattic/android/experimentation/VariationsRepository$Companion {
-	public final fun create (Ljava/lang/String;Ljava/util/Set;Lcom/automattic/android/experimentation/ExperimentLogger;Lkotlinx/coroutines/CoroutineScope;Lkotlinx/coroutines/CoroutineDispatcher;ZLjava/io/File;)Lcom/automattic/android/experimentation/ExPlat;
-	public static synthetic fun create$default (Lcom/automattic/android/experimentation/VariationsRepository$Companion;Ljava/lang/String;Ljava/util/Set;Lcom/automattic/android/experimentation/ExperimentLogger;Lkotlinx/coroutines/CoroutineScope;Lkotlinx/coroutines/CoroutineDispatcher;ZLjava/io/File;ILjava/lang/Object;)Lcom/automattic/android/experimentation/ExPlat;
-}
-
-public final class com/automattic/android/experimentation/VariationsRepository$DefaultImpls {
-	public static synthetic fun configure$default (Lcom/automattic/android/experimentation/VariationsRepository;Ljava/lang/String;ILjava/lang/Object;)V
-	public static synthetic fun refresh$default (Lcom/automattic/android/experimentation/VariationsRepository;ZILjava/lang/Object;)V
-}
-
-public final class com/automattic/android/experimentation/domain/Assignments {
-	public fun <init> (Ljava/util/Map;IJ)V
-	public final fun component1 ()Ljava/util/Map;
-	public final fun component2 ()I
-	public final fun component3 ()J
-	public final fun copy (Ljava/util/Map;IJ)Lcom/automattic/android/experimentation/domain/Assignments;
-	public static synthetic fun copy$default (Lcom/automattic/android/experimentation/domain/Assignments;Ljava/util/Map;IJILjava/lang/Object;)Lcom/automattic/android/experimentation/domain/Assignments;
-	public fun equals (Ljava/lang/Object;)Z
-	public final fun getFetchedAt ()J
-	public final fun getTimeToLive ()I
-	public final fun getVariations ()Ljava/util/Map;
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
+	public final fun create (Ljava/lang/String;Ljava/util/Set;Lcom/automattic/android/experimentation/ExperimentLogger;ZLjava/io/File;Lkotlinx/coroutines/CoroutineScope;Lkotlinx/coroutines/CoroutineDispatcher;)Lcom/automattic/android/experimentation/ExPlat;
+	public static synthetic fun create$default (Lcom/automattic/android/experimentation/VariationsRepository$Companion;Ljava/lang/String;Ljava/util/Set;Lcom/automattic/android/experimentation/ExperimentLogger;ZLjava/io/File;Lkotlinx/coroutines/CoroutineScope;Lkotlinx/coroutines/CoroutineDispatcher;ILjava/lang/Object;)Lcom/automattic/android/experimentation/ExPlat;
 }
 
 public abstract class com/automattic/android/experimentation/domain/Variation {

--- a/experimentation/build.gradle
+++ b/experimentation/build.gradle
@@ -35,6 +35,10 @@ android {
     }
 }
 
+kotlin {
+    explicitApi()
+}
+
 dependencies {
     def okHttp = "4.12.0"
     implementation "com.squareup.okhttp3:okhttp:$okHttp"

--- a/experimentation/build.gradle
+++ b/experimentation/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id "org.jetbrains.kotlin.android"
     id 'com.automattic.android.publish-to-s3'
     id "com.google.devtools.ksp"
+    id "org.jetbrains.kotlinx.binary-compatibility-validator"
 }
 
 repositories {

--- a/experimentation/src/main/java/com/automattic/android/experimentation/ExPlat.kt
+++ b/experimentation/src/main/java/com/automattic/android/experimentation/ExPlat.kt
@@ -17,7 +17,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import java.io.File
 
-class ExPlat internal constructor(
+public class ExPlat internal constructor(
     private val platform: String,
     private val experiments: Set<Experiment>,
     private val logger: ExperimentLogger,
@@ -31,7 +31,7 @@ class ExPlat internal constructor(
 
     private var anonId: String? = null
 
-    fun configure(anonId: String? = null) {
+    public fun configure(anonId: String? = null) {
         clear()
         this.anonId = anonId
     }
@@ -48,7 +48,7 @@ class ExPlat internal constructor(
      * If the provided [Experiment] was not included in [experiments], then [Control] is returned.
      * If [isDebug] is `true`, an [IllegalArgumentException] is thrown instead.
      */
-    fun getVariation(experiment: Experiment): Variation {
+    public fun getVariation(experiment: Experiment): Variation {
         val experimentIdentifier = experiment.identifier
         if (!experimentIdentifiers.contains(experimentIdentifier)) {
             val message = "ExPlat: experiment not found: \"${experimentIdentifier}\"! " +
@@ -67,15 +67,15 @@ class ExPlat internal constructor(
         }
     }
 
-    fun refreshIfNeeded() {
+    public fun refreshIfNeeded() {
         refresh(refreshStrategy = IF_STALE)
     }
 
-    fun forceRefresh() {
+    public fun forceRefresh() {
         refresh(refreshStrategy = ALWAYS)
     }
 
-    fun clear() {
+    public fun clear() {
         logger.d("ExPlat: clearing cached assignments and active variations")
         activeVariations.clear()
         anonId = null
@@ -115,8 +115,8 @@ class ExPlat internal constructor(
 
     private enum class RefreshStrategy { ALWAYS, IF_STALE, NEVER }
 
-    companion object {
-        fun create(
+    public companion object {
+        public fun create(
             platform: String,
             experiments: Set<Experiment>,
             logger: ExperimentLogger,

--- a/experimentation/src/main/java/com/automattic/android/experimentation/ExPlat.kt
+++ b/experimentation/src/main/java/com/automattic/android/experimentation/ExPlat.kt
@@ -27,9 +27,7 @@ public class ExPlat internal constructor(
 
     override fun initialize(anonymousId: String) {
         this.anonymousId = anonymousId
-        coroutineScope.launch {
-            refresh()
-        }
+        refresh(IF_STALE)
     }
 
     override fun getVariation(experiment: Experiment): Variation {
@@ -48,10 +46,6 @@ public class ExPlat internal constructor(
         return activeVariations.getOrPut(experimentIdentifier) {
             getAssignments(NEVER)?.variations?.get(experimentIdentifier) ?: Control
         }
-    }
-
-    override fun refresh(force: Boolean) {
-        refresh(refreshStrategy = if (force) ALWAYS else IF_STALE)
     }
 
     override fun clear() {

--- a/experimentation/src/main/java/com/automattic/android/experimentation/ExPlat.kt
+++ b/experimentation/src/main/java/com/automattic/android/experimentation/ExPlat.kt
@@ -83,7 +83,7 @@ public class ExPlat internal constructor(
     }
 
     private suspend fun fetchAssignments() =
-        repository.fetch(platform, experimentIdentifiers, anonymousId).fold(
+        repository.fetch(platform, experimentIdentifiers, anonymousId.orEmpty()).fold(
             onSuccess = {
                 logger.d("ExPlat: fetching assignments successful with result: $it")
             },

--- a/experimentation/src/main/java/com/automattic/android/experimentation/ExPlat.kt
+++ b/experimentation/src/main/java/com/automattic/android/experimentation/ExPlat.kt
@@ -13,7 +13,7 @@ import kotlinx.coroutines.launch
 
 public class ExPlat internal constructor(
     private val platform: String,
-    private val experiments: Set<Experiment>,
+    experiments: Set<Experiment>,
     private val logger: ExperimentLogger,
     private val coroutineScope: CoroutineScope,
     private val isDebug: Boolean,

--- a/experimentation/src/main/java/com/automattic/android/experimentation/ExPlat.kt
+++ b/experimentation/src/main/java/com/automattic/android/experimentation/ExPlat.kt
@@ -25,15 +25,11 @@ public class ExPlat internal constructor(
 
     private var anonymousId: String? = null
 
-    init {
+    override fun initialize(anonymousId: String) {
+        this.anonymousId = anonymousId
         coroutineScope.launch {
             refresh()
         }
-    }
-
-    override fun configure(anonymousId: String?) {
-        clear()
-        this.anonymousId = anonymousId
     }
 
     override fun getVariation(experiment: Experiment): Variation {
@@ -75,7 +71,8 @@ public class ExPlat internal constructor(
         val cachedAssignments: Assignments? = repository.getCached()
         if (refreshStrategy == ALWAYS ||
             cachedAssignments == null ||
-            (refreshStrategy == IF_STALE && assignmentsValidator.isStale(cachedAssignments))
+            (refreshStrategy == IF_STALE && assignmentsValidator.isStale(cachedAssignments)) ||
+            cachedAssignments.anonymousId != anonymousId
         ) {
             coroutineScope.launch { fetchAssignments() }
         }

--- a/experimentation/src/main/java/com/automattic/android/experimentation/ExPlat.kt
+++ b/experimentation/src/main/java/com/automattic/android/experimentation/ExPlat.kt
@@ -69,7 +69,7 @@ public class ExPlat internal constructor(
 
     private fun getAssignments(): Assignments? = repository.getCached()
 
-    private fun invalidateCache(): Assignments? {
+    private fun invalidateCache() {
         val cachedAssignments: Assignments? = repository.getCached()
         if (cachedAssignments == null ||
             assignmentsValidator.isStale(cachedAssignments) ||
@@ -77,7 +77,6 @@ public class ExPlat internal constructor(
         ) {
             coroutineScope.launch { fetchAssignments() }
         }
-        return cachedAssignments
     }
 
     private suspend fun fetchAssignments() {

--- a/experimentation/src/main/java/com/automattic/android/experimentation/ExPlat.kt
+++ b/experimentation/src/main/java/com/automattic/android/experimentation/ExPlat.kt
@@ -30,18 +30,6 @@ public class ExPlat internal constructor(
         this.anonId = anonId
     }
 
-    /**
-     * This returns the current active [Variation] for the provided [Experiment].
-     *
-     * If no active [Variation] is found, we can assume this is the first time this method is being
-     * called for the provided [Experiment] during the current session. In this case, the [Variation]
-     * is returned from the cached [Assignments] and then set as active. If the cached [Assignments]
-     * is stale and [shouldRefreshIfStale] is `true`, then new [Assignments] are fetched and their
-     * variations are going to be returned by this method on the next session.
-     *
-     * If the provided [Experiment] was not included in [experiments], then [Control] is returned.
-     * If [isDebug] is `true`, an [IllegalArgumentException] is thrown instead.
-     */
     override fun getVariation(experiment: Experiment): Variation {
         val experimentIdentifier = experiment.identifier
         if (!experimentIdentifiers.contains(experimentIdentifier)) {

--- a/experimentation/src/main/java/com/automattic/android/experimentation/ExPlat.kt
+++ b/experimentation/src/main/java/com/automattic/android/experimentation/ExPlat.kt
@@ -49,12 +49,8 @@ public class ExPlat internal constructor(
         }
     }
 
-    override fun refreshIfNeeded() {
-        refresh(refreshStrategy = IF_STALE)
-    }
-
-    override fun forceRefresh() {
-        refresh(refreshStrategy = ALWAYS)
+    override fun refresh(force: Boolean) {
+        refresh(refreshStrategy = if (force) ALWAYS else IF_STALE)
     }
 
     override fun clear() {

--- a/experimentation/src/main/java/com/automattic/android/experimentation/ExPlat.kt
+++ b/experimentation/src/main/java/com/automattic/android/experimentation/ExPlat.kt
@@ -25,6 +25,12 @@ public class ExPlat internal constructor(
 
     private var anonId: String? = null
 
+    init {
+        coroutineScope.launch {
+            refresh()
+        }
+    }
+
     override fun configure(anonId: String?) {
         clear()
         this.anonId = anonId

--- a/experimentation/src/main/java/com/automattic/android/experimentation/Experiment.kt
+++ b/experimentation/src/main/java/com/automattic/android/experimentation/Experiment.kt
@@ -1,5 +1,5 @@
 package com.automattic.android.experimentation
 
-interface Experiment {
-    val identifier: String
+public interface Experiment {
+    public val identifier: String
 }

--- a/experimentation/src/main/java/com/automattic/android/experimentation/Experiment.kt
+++ b/experimentation/src/main/java/com/automattic/android/experimentation/Experiment.kt
@@ -1,5 +1,4 @@
 package com.automattic.android.experimentation
 
-public interface Experiment {
-    public val identifier: String
-}
+@JvmInline
+public value class Experiment(public val identifier: String)

--- a/experimentation/src/main/java/com/automattic/android/experimentation/ExperimentLogger.kt
+++ b/experimentation/src/main/java/com/automattic/android/experimentation/ExperimentLogger.kt
@@ -1,6 +1,6 @@
 package com.automattic.android.experimentation
 
-interface ExperimentLogger {
-    fun d(message: String)
-    fun e(message: String, throwable: Throwable)
+public interface ExperimentLogger {
+    public fun d(message: String)
+    public fun e(message: String, throwable: Throwable)
 }

--- a/experimentation/src/main/java/com/automattic/android/experimentation/ExperimentLogger.kt
+++ b/experimentation/src/main/java/com/automattic/android/experimentation/ExperimentLogger.kt
@@ -2,5 +2,5 @@ package com.automattic.android.experimentation
 
 public interface ExperimentLogger {
     public fun d(message: String)
-    public fun e(message: String, throwable: Throwable)
+    public fun e(message: String, throwable: Throwable? = null)
 }

--- a/experimentation/src/main/java/com/automattic/android/experimentation/VariationsRepository.kt
+++ b/experimentation/src/main/java/com/automattic/android/experimentation/VariationsRepository.kt
@@ -1,0 +1,59 @@
+package com.automattic.android.experimentation
+
+import com.automattic.android.experimentation.domain.AssignmentsValidator
+import com.automattic.android.experimentation.domain.SystemClock
+import com.automattic.android.experimentation.domain.Variation
+import com.automattic.android.experimentation.local.FileBasedCache
+import com.automattic.android.experimentation.remote.ExperimentRestClient
+import com.automattic.android.experimentation.repository.AssignmentsRepository
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import java.io.File
+
+public interface VariationsRepository {
+    public fun configure(anonId: String? = null)
+
+    /**
+     * This returns the current active [Variation] for the provided [Experiment].
+     *
+     * If no active [Variation] is found, we can assume this is the first time this method is being
+     * called for the provided [Experiment] during the current session. In this case, the [Variation]
+     * is returned from the cached [Assignments] and then set as active. If the cached [Assignments]
+     * is stale and [shouldRefreshIfStale] is `true`, then new [Assignments] are fetched and their
+     * variations are going to be returned by this method on the next session.
+     *
+     * If the provided [Experiment] was not included in [experiments], then [Control] is returned.
+     * If [isDebug] is `true`, an [IllegalArgumentException] is thrown instead.
+     */
+    public fun getVariation(experiment: Experiment): Variation
+    public fun refreshIfNeeded()
+    public fun forceRefresh()
+    public fun clear()
+
+    public companion object {
+        public fun create(
+            platform: String,
+            experiments: Set<Experiment>,
+            logger: ExperimentLogger,
+            coroutineScope: CoroutineScope,
+            dispatcher: CoroutineDispatcher = Dispatchers.IO,
+            isDebug: Boolean,
+            cacheDir: File,
+        ): ExPlat {
+            val restClient = ExperimentRestClient(dispatcher = dispatcher)
+            val cache = FileBasedCache(cacheDir, dispatcher = dispatcher, scope = coroutineScope)
+            val assignmentsRepository = AssignmentsRepository(restClient, cache)
+            val assignmentsValidator = AssignmentsValidator(SystemClock())
+            return ExPlat(
+                platform = platform,
+                experiments = experiments,
+                logger = logger,
+                coroutineScope = coroutineScope,
+                isDebug = isDebug,
+                assignmentsValidator = assignmentsValidator,
+                repository = assignmentsRepository,
+            )
+        }
+    }
+}

--- a/experimentation/src/main/java/com/automattic/android/experimentation/VariationsRepository.kt
+++ b/experimentation/src/main/java/com/automattic/android/experimentation/VariationsRepository.kt
@@ -36,11 +36,6 @@ public interface VariationsRepository {
     public fun getVariation(experiment: Experiment): Variation
 
     /**
-     * Refreshes the [Assignments] from the server.
-     */
-    public fun refresh(force: Boolean = false)
-
-    /**
      * Clears the [VariationsRepository] state. This will clear "active" [Variation]s.
      * See [getVariation] for more details.
      */

--- a/experimentation/src/main/java/com/automattic/android/experimentation/VariationsRepository.kt
+++ b/experimentation/src/main/java/com/automattic/android/experimentation/VariationsRepository.kt
@@ -12,6 +12,11 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import java.io.File
 
+/**
+ * Repository for accessing [Variation]s for [Experiment]s.
+ *
+ * Should be a Singleton, as it keeps track of the "active" [Variation]s. See [getVariation] for more details.
+ */
 public interface VariationsRepository {
     /**
      * Configures the [VariationsRepository] with an anonymous identifier.

--- a/experimentation/src/main/java/com/automattic/android/experimentation/VariationsRepository.kt
+++ b/experimentation/src/main/java/com/automattic/android/experimentation/VariationsRepository.kt
@@ -22,7 +22,7 @@ public interface VariationsRepository {
      * Configures the [VariationsRepository] with an anonymous identifier.
      * This identifier is used to fetch the [Assignments] from the server.
      */
-    public fun configure(anonId: String? = null)
+    public fun configure(anonymousId: String? = null)
 
     /**
      * Returns a [Variation] for the provided [Experiment]. [Variation] is then considered "active".
@@ -62,23 +62,22 @@ public interface VariationsRepository {
             platform: String,
             experiments: Set<Experiment>,
             logger: ExperimentLogger,
-            coroutineScope: CoroutineScope,
-            dispatcher: CoroutineDispatcher = Dispatchers.IO,
             isDebug: Boolean,
             cacheDir: File,
+            coroutineScope: CoroutineScope,
+            dispatcher: CoroutineDispatcher = Dispatchers.IO,
         ): ExPlat {
-            val restClient = ExperimentRestClient(dispatcher = dispatcher)
-            val cache = FileBasedCache(cacheDir, dispatcher = dispatcher, scope = coroutineScope)
-            val assignmentsRepository = AssignmentsRepository(restClient, cache)
-            val assignmentsValidator = AssignmentsValidator(SystemClock())
             return ExPlat(
                 platform = platform,
                 experiments = experiments,
                 logger = logger,
                 coroutineScope = coroutineScope,
                 isDebug = isDebug,
-                assignmentsValidator = assignmentsValidator,
-                repository = assignmentsRepository,
+                assignmentsValidator = AssignmentsValidator(SystemClock()),
+                repository = AssignmentsRepository(
+                    ExperimentRestClient(dispatcher = dispatcher),
+                    FileBasedCache(cacheDir, dispatcher = dispatcher, scope = coroutineScope)
+                ),
             )
         }
     }

--- a/experimentation/src/main/java/com/automattic/android/experimentation/VariationsRepository.kt
+++ b/experimentation/src/main/java/com/automattic/android/experimentation/VariationsRepository.kt
@@ -19,15 +19,15 @@ import java.io.File
  */
 public interface VariationsRepository {
     /**
-     * Configures the [VariationsRepository] with an anonymous identifier.
+     * Initializes the [VariationsRepository] with an anonymous identifier.
      * This identifier is used to fetch the [Assignments] from the server.
      */
-    public fun configure(anonymousId: String? = null)
+    public fun initialize(anonymousId: String)
 
     /**
      * Returns a [Variation] for the provided [Experiment]. [Variation] is then considered "active".
      *
-     * Subsequent calls to this method with the same [Experiment] will return the same "active" [Variation] until [clear] or [configure] is called.
+     * Subsequent calls to this method with the same [Experiment] will return the same "active" [Variation] until [clear] or is called.
      * This is a safety mechanism that prevents mixing [Variation] during the same session as this might lead to unexpected behavior.
      *
      * @param experiment [Experiment] for which to get the [Variation]. Must be included in the set provided via [create].
@@ -76,7 +76,7 @@ public interface VariationsRepository {
                 assignmentsValidator = AssignmentsValidator(SystemClock()),
                 repository = AssignmentsRepository(
                     ExperimentRestClient(dispatcher = dispatcher),
-                    FileBasedCache(cacheDir, dispatcher = dispatcher, scope = coroutineScope)
+                    FileBasedCache(cacheDir, dispatcher = dispatcher, scope = coroutineScope),
                 ),
             )
         }

--- a/experimentation/src/main/java/com/automattic/android/experimentation/VariationsRepository.kt
+++ b/experimentation/src/main/java/com/automattic/android/experimentation/VariationsRepository.kt
@@ -33,8 +33,7 @@ public interface VariationsRepository {
     /**
      * Refreshes the [Assignments] from the server.
      */
-    public fun refreshIfNeeded()
-    public fun forceRefresh()
+    public fun refresh(force: Boolean = false)
 
     /**
      * Clears the [VariationsRepository] state. This will clear "active" [Variation]s.

--- a/experimentation/src/main/java/com/automattic/android/experimentation/VariationsRepository.kt
+++ b/experimentation/src/main/java/com/automattic/android/experimentation/VariationsRepository.kt
@@ -50,14 +50,14 @@ public interface VariationsRepository {
          * @param logger to log errors and debug information.
          * @param coroutineScope to use for async operations. Preferably a [CoroutineScope] that is tied to the lifecycle of the application.
          * @param dispatcher to use for async I/O operations. Defaults to [Dispatchers.IO].
-         * @param isDebug If `true`, [getVariation] will throw an [IllegalArgumentException] if the provided [Experiment] is not found.
+         * @param failFast If `true`, [getVariation] will throw exceptions if the [VariationsRepository] is not initialized or if the [Experiment] is not found.
          * @param cacheDir Directory to use for caching the [Assignments]. This directory should be private to the application.
          */
         public fun create(
             platform: String,
             experiments: Set<Experiment>,
             logger: ExperimentLogger,
-            isDebug: Boolean,
+            failFast: Boolean,
             cacheDir: File,
             coroutineScope: CoroutineScope,
             dispatcher: CoroutineDispatcher = Dispatchers.IO,
@@ -67,7 +67,7 @@ public interface VariationsRepository {
                 experiments = experiments,
                 logger = logger,
                 coroutineScope = coroutineScope,
-                isDebug = isDebug,
+                failFast = failFast,
                 assignmentsValidator = AssignmentsValidator(SystemClock()),
                 repository = AssignmentsRepository(
                     ExperimentRestClient(dispatcher = dispatcher),

--- a/experimentation/src/main/java/com/automattic/android/experimentation/domain/Assignments.kt
+++ b/experimentation/src/main/java/com/automattic/android/experimentation/domain/Assignments.kt
@@ -1,6 +1,6 @@
 package com.automattic.android.experimentation.domain
 
-public data class Assignments(
+internal data class Assignments(
     val variations: Map<String, Variation>,
     val timeToLive: Int,
     val fetchedAt: Long,

--- a/experimentation/src/main/java/com/automattic/android/experimentation/domain/Assignments.kt
+++ b/experimentation/src/main/java/com/automattic/android/experimentation/domain/Assignments.kt
@@ -4,4 +4,5 @@ public data class Assignments(
     val variations: Map<String, Variation>,
     val timeToLive: Int,
     val fetchedAt: Long,
+    val anonymousId: String,
 )

--- a/experimentation/src/main/java/com/automattic/android/experimentation/domain/Assignments.kt
+++ b/experimentation/src/main/java/com/automattic/android/experimentation/domain/Assignments.kt
@@ -1,6 +1,6 @@
 package com.automattic.android.experimentation.domain
 
-data class Assignments(
+public data class Assignments(
     val variations: Map<String, Variation>,
     val timeToLive: Int,
     val fetchedAt: Long,

--- a/experimentation/src/main/java/com/automattic/android/experimentation/domain/Variation.kt
+++ b/experimentation/src/main/java/com/automattic/android/experimentation/domain/Variation.kt
@@ -1,6 +1,6 @@
 package com.automattic.android.experimentation.domain
 
-sealed class Variation {
-    data class Treatment(val name: String) : Variation()
-    data object Control : Variation()
+public sealed class Variation {
+    public data class Treatment(val name: String) : Variation()
+    public data object Control : Variation()
 }

--- a/experimentation/src/main/java/com/automattic/android/experimentation/local/CacheDto.kt
+++ b/experimentation/src/main/java/com/automattic/android/experimentation/local/CacheDto.kt
@@ -1,0 +1,15 @@
+package com.automattic.android.experimentation.local
+
+import com.automattic.android.experimentation.remote.AssignmentsDto
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+internal class CacheDto(
+    @Json(name = "assignmentsDto")
+    val assignmentsDto: AssignmentsDto,
+    @Json(name = "fetchedAt")
+    val fetchedAt: Long,
+    @Json(name = "anonymousId")
+    val anonymousId: String,
+)

--- a/experimentation/src/main/java/com/automattic/android/experimentation/local/FileBasedCache.kt
+++ b/experimentation/src/main/java/com/automattic/android/experimentation/local/FileBasedCache.kt
@@ -1,7 +1,6 @@
 package com.automattic.android.experimentation.local
 
 import com.automattic.android.experimentation.domain.Assignments
-import com.automattic.android.experimentation.remote.AssignmentsDtoJsonAdapter
 import com.automattic.android.experimentation.remote.AssignmentsDtoMapper.toAssignments
 import com.automattic.android.experimentation.remote.AssignmentsDtoMapper.toDto
 import com.squareup.moshi.Moshi
@@ -15,7 +14,7 @@ import java.io.File
 internal class FileBasedCache(
     cacheDir: File,
     private val moshi: Moshi = Moshi.Builder().build(),
-    private val jsonAdapter: AssignmentsDtoJsonAdapter = AssignmentsDtoJsonAdapter(moshi),
+    private val cacheDtoJsonAdapter: CacheDtoJsonAdapter = CacheDtoJsonAdapter(moshi),
     private val dispatcher: CoroutineDispatcher,
     scope: CoroutineScope,
 ) {
@@ -42,25 +41,20 @@ internal class FileBasedCache(
 
     suspend fun getAssignments(): Assignments? {
         return withContext(dispatcher) {
-            assignmentsFile.takeIf { it.exists() }?.readText()?.let { json ->
-                val fromJson = wrapperAdapter.fromJson(json) ?: return@let null
+            assignmentsFile.takeIf { it.exists() }?.readText()?.let { json: String ->
+                val fromJson = cacheDtoJsonAdapter.fromJson(json) ?: return@let null
 
-                val (fetchedAt, dtoJson) = fromJson.toList().first()
-
-                val dto = jsonAdapter.fromJson(dtoJson)
-
-                dto?.toAssignments(fetchedAt)
+                fromJson.assignmentsDto.toAssignments(fromJson.fetchedAt, fromJson.anonymousId)
             }
         }
     }
 
     suspend fun saveAssignments(assignments: Assignments) {
         withContext(dispatcher) {
-            val (dto, fetchedAt) = assignments.toDto()
-            val dtoJson = jsonAdapter.serializeNulls().toJson(dto)
+            val cacheDto: CacheDto = assignments.toDto()
+            val dtoJson = cacheDtoJsonAdapter.serializeNulls().toJson(cacheDto)
 
-            val wrapperJson = wrapperAdapter.toJson(mapOf(fetchedAt to dtoJson))
-            assignmentsFile.writeText(wrapperJson)
+            assignmentsFile.writeText(dtoJson)
 
             latestMutable = assignments
         }

--- a/experimentation/src/main/java/com/automattic/android/experimentation/local/FileBasedCache.kt
+++ b/experimentation/src/main/java/com/automattic/android/experimentation/local/FileBasedCache.kt
@@ -44,7 +44,10 @@ internal class FileBasedCache(
             assignmentsFile.takeIf { it.exists() }?.readText()?.let { json: String ->
                 val fromJson = cacheDtoJsonAdapter.fromJson(json) ?: return@let null
 
-                fromJson.assignmentsDto.toAssignments(fromJson.fetchedAt, fromJson.anonymousId)
+                fromJson.assignmentsDto.toAssignments(
+                    fetchedAt = fromJson.fetchedAt,
+                    anonymousId = fromJson.anonymousId,
+                )
             }
         }
     }

--- a/experimentation/src/main/java/com/automattic/android/experimentation/remote/AssignmentsDtoMapper.kt
+++ b/experimentation/src/main/java/com/automattic/android/experimentation/remote/AssignmentsDtoMapper.kt
@@ -2,10 +2,11 @@ package com.automattic.android.experimentation.remote
 
 import com.automattic.android.experimentation.domain.Assignments
 import com.automattic.android.experimentation.domain.Variation
+import com.automattic.android.experimentation.local.CacheDto
 
 internal object AssignmentsDtoMapper {
     private const val CONTROL = "control"
-    fun AssignmentsDto.toAssignments(fetchedAt: Long): Assignments {
+    fun AssignmentsDto.toAssignments(fetchedAt: Long, anonymousId: String): Assignments {
         return Assignments(
             variations = variations.mapValues { (_, value) ->
                 // API returns null for control group, but a previous implementation (back from FluxC)
@@ -18,17 +19,22 @@ internal object AssignmentsDtoMapper {
             },
             timeToLive = ttl,
             fetchedAt = fetchedAt,
+            anonymousId = anonymousId,
         )
     }
-    fun Assignments.toDto(): Pair<AssignmentsDto, Long> {
-        return AssignmentsDto(
-            variations = variations.mapValues { (_, value) ->
-                when (value) {
-                    is Variation.Control -> CONTROL
-                    is Variation.Treatment -> value.name
-                }
-            },
-            ttl = timeToLive,
-        ) to fetchedAt
+    fun Assignments.toDto(): CacheDto {
+        return CacheDto(
+            assignmentsDto = AssignmentsDto(
+                variations = variations.mapValues { (_, value) ->
+                    when (value) {
+                        is Variation.Control -> CONTROL
+                        is Variation.Treatment -> value.name
+                    }
+                },
+                ttl = timeToLive,
+            ),
+            fetchedAt = fetchedAt,
+            anonymousId = anonymousId,
+        )
     }
 }

--- a/experimentation/src/main/java/com/automattic/android/experimentation/remote/ExperimentRestClient.kt
+++ b/experimentation/src/main/java/com/automattic/android/experimentation/remote/ExperimentRestClient.kt
@@ -39,7 +39,10 @@ internal class ExperimentRestClient(
                 } else {
                     runCatching {
                         val dto = jsonAdapter.fromJson(response.body!!.source())!!
-                        dto.toAssignments(clock.currentTimeSeconds())
+                        dto.toAssignments(
+                            fetchedAt = clock.currentTimeSeconds(),
+                            anonymousId = anonymousId!!,
+                        )
                     }
                 }
             }

--- a/experimentation/src/main/java/com/automattic/android/experimentation/remote/ExperimentRestClient.kt
+++ b/experimentation/src/main/java/com/automattic/android/experimentation/remote/ExperimentRestClient.kt
@@ -23,7 +23,7 @@ internal class ExperimentRestClient(
     suspend fun fetchAssignments(
         platform: String,
         experimentNames: List<String>,
-        anonymousId: String? = null,
+        anonymousId: String,
     ): Result<Assignments> {
         val url = urlBuilder.buildUrl(platform, experimentNames, anonymousId)
 
@@ -41,7 +41,7 @@ internal class ExperimentRestClient(
                         val dto = jsonAdapter.fromJson(response.body!!.source())!!
                         dto.toAssignments(
                             fetchedAt = clock.currentTimeSeconds(),
-                            anonymousId = anonymousId!!,
+                            anonymousId = anonymousId,
                         )
                     }
                 }

--- a/experimentation/src/main/java/com/automattic/android/experimentation/repository/AssignmentsRepository.kt
+++ b/experimentation/src/main/java/com/automattic/android/experimentation/repository/AssignmentsRepository.kt
@@ -12,7 +12,7 @@ internal class AssignmentsRepository(
     suspend fun fetch(
         platform: String,
         experimentNames: List<String>,
-        anonymousId: String? = null,
+        anonymousId: String,
     ): Result<Assignments> {
         val fetchResult =
             experimentRestClient.fetchAssignments(platform, experimentNames, anonymousId)

--- a/experimentation/src/test/java/com/automattic/android/experimentation/ExPlatTest.kt
+++ b/experimentation/src/test/java/com/automattic/android/experimentation/ExPlatTest.kt
@@ -34,7 +34,7 @@ internal class ExPlatTest {
         enqueueSuccessfulNetworkResponse()
         val exPlat = createExPlat()
 
-        exPlat.refreshIfNeeded()
+        exPlat.refresh()
         runCurrent()
 
         assertThat(tempCache.latest).isEqualTo(testAssignment)
@@ -46,7 +46,7 @@ internal class ExPlatTest {
         val exPlat = createExPlat(clock = { 3601 })
         tempCache.saveAssignments(testAssignment.copy(timeToLive = 3600, fetchedAt = 0))
 
-        exPlat.refreshIfNeeded()
+        exPlat.refresh()
         runCurrent()
 
         assertThat(tempCache.latest).isEqualTo(
@@ -60,7 +60,7 @@ internal class ExPlatTest {
         val exPlat = createExPlat(clock = { 3599 })
         tempCache.saveAssignments(testAssignment.copy(timeToLive = 3600))
 
-        exPlat.refreshIfNeeded()
+        exPlat.refresh()
         runCurrent()
 
         assertThat(tempCache.latest).isEqualTo(
@@ -74,7 +74,7 @@ internal class ExPlatTest {
         val exPlat = createExPlat(clock = { 3599 })
         tempCache.saveAssignments(testAssignment.copy(timeToLive = 3600))
 
-        exPlat.forceRefresh()
+        exPlat.refresh(force = true)
         runCurrent()
 
         assertThat(tempCache.latest).isEqualTo(
@@ -110,7 +110,7 @@ internal class ExPlatTest {
                 ),
             )
             val firstGet = exPlat.getVariation(testExperiment)
-            exPlat.forceRefresh()
+            exPlat.refresh(force = true)
             runCurrent()
 
             val secondGet = exPlat.getVariation(testExperiment)

--- a/experimentation/src/test/java/com/automattic/android/experimentation/ExPlatTest.kt
+++ b/experimentation/src/test/java/com/automattic/android/experimentation/ExPlatTest.kt
@@ -22,7 +22,6 @@ import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.Test
 import kotlin.io.path.createTempDirectory
-import kotlinx.coroutines.test.advanceUntilIdle
 
 @ExperimentalCoroutinesApi
 internal class ExPlatTest {
@@ -91,7 +90,7 @@ internal class ExPlatTest {
             val exPlat = createExPlat(clock = { 3601 }, init = { })
             enqueueSuccessfulNetworkResponse(variation = Treatment("variation2"))
             tempCache.saveAssignments(
-                testAssignment.copy(mapOf(testExperimentName to Control), fetchedAt = 0, timeToLive = 3600)
+                testAssignment.copy(mapOf(testExperimentName to Control), fetchedAt = 0, timeToLive = 3600),
             )
             exPlat.initialize(anonymousId)
             val firstGet = exPlat.getVariation(testExperiment)
@@ -135,7 +134,7 @@ internal class ExPlatTest {
             enqueueSuccessfulNetworkResponse(variation = Treatment("variation2"))
             val exPlat = createExPlat(init = { })
             tempCache.saveAssignments(
-                testAssignment.copy(mapOf(testExperimentName to Control), fetchedAt = 0)
+                testAssignment.copy(mapOf(testExperimentName to Control), fetchedAt = 0),
             )
 
             exPlat.initialize("newId")
@@ -147,7 +146,7 @@ internal class ExPlatTest {
                     3600,
                     0,
                     "newId",
-                )
+                ),
             )
         }
 

--- a/experimentation/src/test/java/com/automattic/android/experimentation/ExPlatTest.kt
+++ b/experimentation/src/test/java/com/automattic/android/experimentation/ExPlatTest.kt
@@ -101,7 +101,10 @@ internal class ExPlatTest {
     @Test
     fun `getting variation for the second time returns the same value, even if cache was updated`() =
         runTest {
-            val exPlat = createExPlat(clock = { 123 }).apply { clear() }
+            val exPlat = createExPlat(clock = { 123 }).apply {
+                clear()
+                runCurrent()
+            }
             enqueueSuccessfulNetworkResponse(variation = Treatment("variation2"))
             tempCache.saveAssignments(
                 testAssignment.copy(
@@ -144,10 +147,12 @@ internal class ExPlatTest {
     private val testVariationName = "testVariation"
     private val testExperiment = Experiment(identifier = testExperimentName)
     private val testVariation = Treatment(testVariationName)
+    private val anonymousId = "id"
     private val testAssignment = Assignments(
         variations = mapOf(testExperimentName to testVariation),
         timeToLive = 3600,
         fetchedAt = 0L,
+        anonymousId = anonymousId,
     )
 
     private fun TestScope.createExPlat(

--- a/experimentation/src/test/java/com/automattic/android/experimentation/ExPlatTest.kt
+++ b/experimentation/src/test/java/com/automattic/android/experimentation/ExPlatTest.kt
@@ -150,6 +150,16 @@ internal class ExPlatTest {
             )
         }
 
+    @Test
+    fun `getting variations without initializing throws an exception`() = runTest {
+        val exPlat = createExPlat(init = { })
+
+        assertThatThrownBy {
+            exPlat.getVariation(testExperiment)
+        }.isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("anonymousId is null")
+    }
+
     private val testExperimentName = "testExperiment"
     private val testVariationName = "testVariation"
     private val testExperiment = Experiment(identifier = testExperimentName)

--- a/experimentation/src/test/java/com/automattic/android/experimentation/ExPlatTest.kt
+++ b/experimentation/src/test/java/com/automattic/android/experimentation/ExPlatTest.kt
@@ -202,7 +202,7 @@ internal class ExPlatTest {
                 override fun e(message: String, throwable: Throwable?) = Unit
             },
             coroutineScope = coroutineScope,
-            isDebug = true,
+            failFast = true,
             assignmentsValidator = AssignmentsValidator(clock = clock),
             repository = AssignmentsRepository(restClient, tempCache),
         ).apply(init)

--- a/experimentation/src/test/java/com/automattic/android/experimentation/ExPlatTest.kt
+++ b/experimentation/src/test/java/com/automattic/android/experimentation/ExPlatTest.kt
@@ -133,9 +133,7 @@ internal class ExPlatTest {
 
     private val testExperimentName = "testExperiment"
     private val testVariationName = "testVariation"
-    private val testExperiment = object : Experiment {
-        override val identifier: String = testExperimentName
-    }
+    private val testExperiment = Experiment(identifier = testExperimentName)
     private val testVariation = Treatment(testVariationName)
     private val testAssignment = Assignments(
         variations = mapOf(testExperimentName to testVariation),

--- a/experimentation/src/test/java/com/automattic/android/experimentation/ExPlatTest.kt
+++ b/experimentation/src/test/java/com/automattic/android/experimentation/ExPlatTest.kt
@@ -22,6 +22,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.Test
 import kotlin.io.path.createTempDirectory
+import kotlinx.coroutines.test.advanceUntilIdle
 
 @ExperimentalCoroutinesApi
 internal class ExPlatTest {
@@ -30,23 +31,23 @@ internal class ExPlatTest {
     private lateinit var tempCache: FileBasedCache
 
     @Test
-    fun `refreshing in case of empty cache is successful`() = runTest {
+    fun `initializing in case of empty cache is fetches assignments`() = runTest {
         enqueueSuccessfulNetworkResponse()
-        val exPlat = createExPlat()
+        val exPlat = createExPlat(init = {})
 
-        exPlat.refresh()
+        exPlat.initialize(anonymousId)
         runCurrent()
 
         assertThat(tempCache.latest).isEqualTo(testAssignment)
     }
 
     @Test
-    fun `refreshing in case of stale cache is successful`() = runTest {
+    fun `initializing in case of stale cache updates it`() = runTest {
         enqueueSuccessfulNetworkResponse()
-        val exPlat = createExPlat(clock = { 3601 })
+        val exPlat = createExPlat(clock = { 3601 }, init = { })
         tempCache.saveAssignments(testAssignment.copy(timeToLive = 3600, fetchedAt = 0))
 
-        exPlat.refresh()
+        exPlat.initialize(anonymousId)
         runCurrent()
 
         assertThat(tempCache.latest).isEqualTo(
@@ -55,30 +56,16 @@ internal class ExPlatTest {
     }
 
     @Test
-    fun `refreshing in case of fresh cache doesn't fetch new assignments`() = runTest {
+    fun `initializing in case of fresh cache doesn't fetch new assignments`() = runTest {
         enqueueSuccessfulNetworkResponse()
-        val exPlat = createExPlat(clock = { 3599 })
+        val exPlat = createExPlat(clock = { 3599 }, init = { })
         tempCache.saveAssignments(testAssignment.copy(timeToLive = 3600))
 
-        exPlat.refresh()
+        exPlat.initialize(anonymousId)
         runCurrent()
 
         assertThat(tempCache.latest).isEqualTo(
             testAssignment,
-        )
-    }
-
-    @Test
-    fun `force refreshing fetches new assignments, even if cache is fresh`() = runTest {
-        enqueueSuccessfulNetworkResponse()
-        val exPlat = createExPlat(clock = { 3599 })
-        tempCache.saveAssignments(testAssignment.copy(timeToLive = 3600))
-
-        exPlat.refresh(force = true)
-        runCurrent()
-
-        assertThat(tempCache.latest).isEqualTo(
-            testAssignment.copy(fetchedAt = 3599),
         )
     }
 
@@ -101,19 +88,17 @@ internal class ExPlatTest {
     @Test
     fun `getting variation for the second time returns the same value, even if cache was updated`() =
         runTest {
-            val exPlat = createExPlat(clock = { 123 }, init = { })
+            val exPlat = createExPlat(clock = { 3601 }, init = { })
             enqueueSuccessfulNetworkResponse(variation = Treatment("variation2"))
             tempCache.saveAssignments(
-                testAssignment.copy(
-                    mapOf(testExperimentName to Control),
-                    fetchedAt = 0,
-                ),
+                testAssignment.copy(mapOf(testExperimentName to Control), fetchedAt = 0, timeToLive = 3600)
             )
+            exPlat.initialize(anonymousId)
             val firstGet = exPlat.getVariation(testExperiment)
-            exPlat.refresh(force = true)
-            runCurrent()
+            runCurrent() // performs fetch from initialization
 
             val secondGet = exPlat.getVariation(testExperiment)
+            runCurrent()
 
             // Even though the cache was updated...
             assertThat(tempCache.latest!!.variations[testExperimentName]).isEqualTo(Treatment("variation2"))
@@ -182,6 +167,7 @@ internal class ExPlatTest {
         clock: Clock = Clock { 0 },
         experiments: Set<Experiment> = setOf(testExperiment),
         init: ExPlat.() -> Unit = {
+            enqueueSuccessfulNetworkResponse()
             initialize(anonymousId)
             runCurrent()
         },
@@ -199,7 +185,6 @@ internal class ExPlatTest {
             scope = coroutineScope,
         )
 
-        enqueueSuccessfulNetworkResponse()
         return ExPlat(
             platform = platform,
             experiments = experiments,

--- a/experimentation/src/test/java/com/automattic/android/experimentation/local/FileBasedCacheTest.kt
+++ b/experimentation/src/test/java/com/automattic/android/experimentation/local/FileBasedCacheTest.kt
@@ -73,6 +73,7 @@ internal class FileBasedCacheTest {
             ),
             timeToLive = 3600,
             fetchedAt = 123456789L,
+            anonymousId = "id",
         )
     }
 }

--- a/experimentation/src/test/java/com/automattic/android/experimentation/remote/AssignmentsDtoMapperTest.kt
+++ b/experimentation/src/test/java/com/automattic/android/experimentation/remote/AssignmentsDtoMapperTest.kt
@@ -29,9 +29,10 @@ class AssignmentsDtoMapperTest {
             ),
             timeToLive = ttl,
             fetchedAt = fetchedAt,
+            anonymousId = "anonymousId",
         )
 
-        val result = dto.toAssignments(fetchedAt)
+        val result = dto.toAssignments(fetchedAt, anonymousId = "anonymousId")
 
         assertEquals(expected, result)
     }

--- a/experimentation/src/test/java/com/automattic/android/experimentation/remote/ExperimentRestClientTest.kt
+++ b/experimentation/src/test/java/com/automattic/android/experimentation/remote/ExperimentRestClientTest.kt
@@ -33,10 +33,11 @@ internal class ExperimentRestClientTest {
                 ),
                 timeToLive = 3600,
                 fetchedAt = TEST_TIMESTAMP,
+                anonymousId = "id",
             ),
         )
 
-        val result = sut.fetchAssignments("", emptyList())
+        val result = sut.fetchAssignments("", emptyList(), anonymousId = "id")
 
         assertEquals(expectedResponse, result)
     }

--- a/experimentation/src/test/java/com/automattic/android/experimentation/remote/ExperimentRestClientTest.kt
+++ b/experimentation/src/test/java/com/automattic/android/experimentation/remote/ExperimentRestClientTest.kt
@@ -48,7 +48,7 @@ internal class ExperimentRestClientTest {
         val errorCode = 503
         server.enqueue(MockResponse().setResponseCode(errorCode))
 
-        val result = sut.fetchAssignments("", emptyList())
+        val result = sut.fetchAssignments("", emptyList(), "")
 
         assertTrue(result.isFailure)
         assertTrue(result.exceptionOrNull()!!.message!!.contains("$errorCode"))
@@ -59,7 +59,7 @@ internal class ExperimentRestClientTest {
         val sut = buildSut(this)
         server.enqueue(MockResponse().setResponseCode(200).setBody("unexpected response"))
 
-        val result = sut.fetchAssignments("", emptyList())
+        val result = sut.fetchAssignments("", emptyList(), "")
 
         assertTrue(result.isFailure)
     }

--- a/sampletracksapp/src/main/java/com/example/sampletracksapp/ExperimentationDialogFragment.kt
+++ b/sampletracksapp/src/main/java/com/example/sampletracksapp/ExperimentationDialogFragment.kt
@@ -70,7 +70,7 @@ class ExperimentationDialogFragment : DialogFragment() {
                     }?.toSet().orEmpty(),
                     cacheDir = cacheDir,
                     coroutineScope = coroutineScope,
-                    isDebug = true,
+                    failFast = true,
                     logger = object : ExperimentLogger {
                         override fun d(message: String) {
                             log(coroutineScope, message)

--- a/sampletracksapp/src/main/java/com/example/sampletracksapp/ExperimentationDialogFragment.kt
+++ b/sampletracksapp/src/main/java/com/example/sampletracksapp/ExperimentationDialogFragment.kt
@@ -37,9 +37,7 @@ class ExperimentationDialogFragment : DialogFragment() {
                 exPlat = VariationsRepository.create(
                     platform = platform.text.toString(),
                     experiments = experiments.text?.toString()?.split(",")?.map {
-                        object : Experiment {
-                            override val identifier: String = it
-                        }
+                        Experiment(identifier = it)
                     }?.toSet().orEmpty(),
                     cacheDir = context!!.cacheDir,
                     coroutineScope = GlobalScope,

--- a/sampletracksapp/src/main/java/com/example/sampletracksapp/ExperimentationDialogFragment.kt
+++ b/sampletracksapp/src/main/java/com/example/sampletracksapp/ExperimentationDialogFragment.kt
@@ -55,14 +55,14 @@ class ExperimentationDialogFragment : DialogFragment() {
             coroutineScope.launch {
                 exPlat.collect { exPlat ->
                     withContext(Dispatchers.Main) {
-                        arrayOf(fetch, generateAnonId, clearCache).forEach {
+                        arrayOf(getVariations, generateAnonId, clear).forEach {
                             it.isEnabled = exPlat != null
                         }
                     }
                 }
             }
 
-            setup.setOnClickListener {
+            initialize.setOnClickListener {
                 exPlat.value = VariationsRepository.create(
                     platform = platform.text.toString(),
                     experiments = experiments.text?.toString()?.split(",")?.map {
@@ -85,8 +85,12 @@ class ExperimentationDialogFragment : DialogFragment() {
                 }
             }
 
-            fetch.setOnClickListener {
-                exPlat.value?.refresh(force = true)
+            getVariations.setOnClickListener {
+                experiments.text?.toString()?.split(",")?.forEach { experiment ->
+                    exPlat.value?.getVariation(Experiment(identifier = experiment)).let { variation ->
+                        log(coroutineScope, "$experiment: $variation")
+                    }
+                }
             }
 
             // Implementation detail. This is not a part of the SDK, used here for testing purposes.
@@ -108,10 +112,9 @@ class ExperimentationDialogFragment : DialogFragment() {
 
             generateAnonId.setOnClickListener {
                 anonId.setText(UUID.randomUUID().toString())
-                exPlat.value?.initialize(anonId.text.toString())
             }
 
-            clearCache.setOnClickListener {
+            clear.setOnClickListener {
                 exPlat.value?.clear()
             }
 
@@ -157,7 +160,7 @@ class ExperimentationDialogFragment : DialogFragment() {
         }
 
         private fun manageSetupAvailability() {
-            binding.setup.isEnabled = binding.platform.text?.isNotEmpty() == true &&
+            binding.initialize.isEnabled = binding.platform.text?.isNotEmpty() == true &&
                 binding.experiments.text?.isNotEmpty() == true
         }
 

--- a/sampletracksapp/src/main/java/com/example/sampletracksapp/ExperimentationDialogFragment.kt
+++ b/sampletracksapp/src/main/java/com/example/sampletracksapp/ExperimentationDialogFragment.kt
@@ -6,9 +6,9 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.DialogFragment
-import com.automattic.android.experimentation.ExPlat
 import com.automattic.android.experimentation.Experiment
 import com.automattic.android.experimentation.ExperimentLogger
+import com.automattic.android.experimentation.VariationsRepository
 import com.example.sampletracksapp.databinding.DialogExperimentationBinding
 import kotlinx.coroutines.GlobalScope
 import java.io.File
@@ -16,7 +16,7 @@ import java.util.UUID
 
 class ExperimentationDialogFragment : DialogFragment() {
 
-    private var exPlat: ExPlat? = null
+    private var exPlat: VariationsRepository? = null
 
     override fun onStart() {
         super.onStart()
@@ -34,7 +34,7 @@ class ExperimentationDialogFragment : DialogFragment() {
     ): View {
         DialogExperimentationBinding.inflate(inflater, container, false).apply {
             setup.setOnClickListener {
-                exPlat = ExPlat.create(
+                exPlat = VariationsRepository.create(
                     platform = platform.text.toString(),
                     experiments = experiments.text?.toString()?.split(",")?.map {
                         object : Experiment {
@@ -59,7 +59,7 @@ class ExperimentationDialogFragment : DialogFragment() {
             }
 
             fetch.setOnClickListener {
-                exPlat?.forceRefresh()
+                exPlat?.refresh(force = true)
             }
 
             // Implementation detail. This is not a part of the SDK, used here for testing purposes.

--- a/sampletracksapp/src/main/java/com/example/sampletracksapp/ExperimentationDialogFragment.kt
+++ b/sampletracksapp/src/main/java/com/example/sampletracksapp/ExperimentationDialogFragment.kt
@@ -76,12 +76,12 @@ class ExperimentationDialogFragment : DialogFragment() {
                             log(coroutineScope, message)
                         }
 
-                        override fun e(message: String, throwable: Throwable) {
+                        override fun e(message: String, throwable: Throwable?) {
                             log(coroutineScope, message)
                         }
                     },
                 ).apply {
-                    configure(anonId.text?.toString().orEmpty())
+                    initialize(anonId.text?.toString().orEmpty())
                 }
             }
 
@@ -108,7 +108,7 @@ class ExperimentationDialogFragment : DialogFragment() {
 
             generateAnonId.setOnClickListener {
                 anonId.setText(UUID.randomUUID().toString())
-                exPlat.value?.configure(anonId.text.toString())
+                exPlat.value?.initialize(anonId.text.toString())
             }
 
             clearCache.setOnClickListener {

--- a/sampletracksapp/src/main/res/layout/dialog_experimentation.xml
+++ b/sampletracksapp/src/main/res/layout/dialog_experimentation.xml
@@ -55,21 +55,21 @@
         android:gravity="center_vertical">
 
         <Button
-            android:id="@+id/setup"
+            android:id="@+id/initialize"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_weight="1"
-            android:text="Setup"
+            android:text="Initialize"
             android:textSize="11sp"
             tools:ignore="ButtonStyle" />
 
         <Button
-            android:id="@+id/fetch"
+            android:id="@+id/getVariations"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginStart="4dp"
             android:layout_weight="1"
-            android:text="Fetch"
+            android:text="Get Variations"
             android:textSize="11sp"
             tools:ignore="ButtonStyle" />
 
@@ -91,12 +91,12 @@
             tools:ignore="ButtonStyle" />
 
         <Button
-            android:id="@+id/clearCache"
+            android:id="@+id/clear"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginStart="4dp"
             android:layout_weight="1"
-            android:text="Clear cache"
+            android:text="Clear SDK\n(cache + state)"
             android:textSize="11sp"
             tools:ignore="ButtonStyle" />
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -13,6 +13,7 @@ pluginManagement {
         id 'androidx.benchmark' version '1.2.4'
         id "com.autonomousapps.dependency-analysis" version gradle.ext.dependencyAnalysisVersion
         id 'com.google.devtools.ksp' version gradle.ext.kspVersion
+        id 'org.jetbrains.kotlinx.binary-compatibility-validator' version '0.16.3'
     }
     repositories {
         maven {


### PR DESCRIPTION
### Description

This PR introduces improvements to the public contract:
- extracts an interface: `VariationsRepository`, so the clients can easily double this in tests + KDoc comments
- introduces a behavior change: refreshing cache on SDK initialization, as I believe this is something that every client would do on initialization anyway
- simplifies `refresh` API (no need for two methods)
- adds `README.md` with an explanation about how to use the SDK

### Testing

The only behavior change has been covered  with automated tests. It's still possible to smoke test using instructions from #241 , if necessary. 