### PR TITLE
Make anon id mandatory. Simplify API, remove `refresh` 

### DIFF
--- a/experimentation/api/experimentation.api
+++ b/experimentation/api/experimentation.api
@@ -1,8 +1,7 @@
 public final class com/automattic/android/experimentation/ExPlat : com/automattic/android/experimentation/VariationsRepository {
 	public fun clear ()V
-	public fun configure (Ljava/lang/String;)V
 	public fun getVariation-98D7FEw (Ljava/lang/String;)Lcom/automattic/android/experimentation/domain/Variation;
-	public fun refresh (Z)V
+	public fun initialize (Ljava/lang/String;)V
 }
 
 public final class com/automattic/android/experimentation/Experiment {
@@ -24,37 +23,20 @@ public abstract interface class com/automattic/android/experimentation/Experimen
 	public abstract fun e (Ljava/lang/String;Ljava/lang/Throwable;)V
 }
 
+public final class com/automattic/android/experimentation/ExperimentLogger$DefaultImpls {
+	public static synthetic fun e$default (Lcom/automattic/android/experimentation/ExperimentLogger;Ljava/lang/String;Ljava/lang/Throwable;ILjava/lang/Object;)V
+}
+
 public abstract interface class com/automattic/android/experimentation/VariationsRepository {
 	public static final field Companion Lcom/automattic/android/experimentation/VariationsRepository$Companion;
 	public abstract fun clear ()V
-	public abstract fun configure (Ljava/lang/String;)V
 	public abstract fun getVariation-98D7FEw (Ljava/lang/String;)Lcom/automattic/android/experimentation/domain/Variation;
-	public abstract fun refresh (Z)V
+	public abstract fun initialize (Ljava/lang/String;)V
 }
 
 public final class com/automattic/android/experimentation/VariationsRepository$Companion {
-	public final fun create (Ljava/lang/String;Ljava/util/Set;Lcom/automattic/android/experimentation/ExperimentLogger;Lkotlinx/coroutines/CoroutineScope;Lkotlinx/coroutines/CoroutineDispatcher;ZLjava/io/File;)Lcom/automattic/android/experimentation/ExPlat;
-	public static synthetic fun create$default (Lcom/automattic/android/experimentation/VariationsRepository$Companion;Ljava/lang/String;Ljava/util/Set;Lcom/automattic/android/experimentation/ExperimentLogger;Lkotlinx/coroutines/CoroutineScope;Lkotlinx/coroutines/CoroutineDispatcher;ZLjava/io/File;ILjava/lang/Object;)Lcom/automattic/android/experimentation/ExPlat;
-}
-
-public final class com/automattic/android/experimentation/VariationsRepository$DefaultImpls {
-	public static synthetic fun configure$default (Lcom/automattic/android/experimentation/VariationsRepository;Ljava/lang/String;ILjava/lang/Object;)V
-	public static synthetic fun refresh$default (Lcom/automattic/android/experimentation/VariationsRepository;ZILjava/lang/Object;)V
-}
-
-public final class com/automattic/android/experimentation/domain/Assignments {
-	public fun <init> (Ljava/util/Map;IJ)V
-	public final fun component1 ()Ljava/util/Map;
-	public final fun component2 ()I
-	public final fun component3 ()J
-	public final fun copy (Ljava/util/Map;IJ)Lcom/automattic/android/experimentation/domain/Assignments;
-	public static synthetic fun copy$default (Lcom/automattic/android/experimentation/domain/Assignments;Ljava/util/Map;IJILjava/lang/Object;)Lcom/automattic/android/experimentation/domain/Assignments;
-	public fun equals (Ljava/lang/Object;)Z
-	public final fun getFetchedAt ()J
-	public final fun getTimeToLive ()I
-	public final fun getVariations ()Ljava/util/Map;
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
+	public final fun create (Ljava/lang/String;Ljava/util/Set;Lcom/automattic/android/experimentation/ExperimentLogger;ZLjava/io/File;Lkotlinx/coroutines/CoroutineScope;Lkotlinx/coroutines/CoroutineDispatcher;)Lcom/automattic/android/experimentation/ExPlat;
+	public static synthetic fun create$default (Lcom/automattic/android/experimentation/VariationsRepository$Companion;Ljava/lang/String;Ljava/util/Set;Lcom/automattic/android/experimentation/ExperimentLogger;ZLjava/io/File;Lkotlinx/coroutines/CoroutineScope;Lkotlinx/coroutines/CoroutineDispatcher;ILjava/lang/Object;)Lcom/automattic/android/experimentation/ExPlat;
 }
 
 public abstract class com/automattic/android/experimentation/domain/Variation {

--- a/experimentation/src/main/java/com/automattic/android/experimentation/ExPlat.kt
+++ b/experimentation/src/main/java/com/automattic/android/experimentation/ExPlat.kt
@@ -27,9 +27,7 @@ public class ExPlat internal constructor(
 
     override fun initialize(anonymousId: String) {
         this.anonymousId = anonymousId
-        coroutineScope.launch {
-            refresh()
-        }
+        refresh(IF_STALE)
     }
 
     override fun getVariation(experiment: Experiment): Variation {
@@ -48,10 +46,6 @@ public class ExPlat internal constructor(
         return activeVariations.getOrPut(experimentIdentifier) {
             getAssignments(NEVER)?.variations?.get(experimentIdentifier) ?: Control
         }
-    }
-
-    override fun refresh(force: Boolean) {
-        refresh(refreshStrategy = if (force) ALWAYS else IF_STALE)
     }
 
     override fun clear() {

--- a/experimentation/src/main/java/com/automattic/android/experimentation/ExPlat.kt
+++ b/experimentation/src/main/java/com/automattic/android/experimentation/ExPlat.kt
@@ -83,7 +83,7 @@ public class ExPlat internal constructor(
     }
 
     private suspend fun fetchAssignments() =
-        repository.fetch(platform, experimentIdentifiers, anonymousId).fold(
+        repository.fetch(platform, experimentIdentifiers, anonymousId.orEmpty()).fold(
             onSuccess = {
                 logger.d("ExPlat: fetching assignments successful with result: $it")
             },

--- a/experimentation/src/main/java/com/automattic/android/experimentation/ExPlat.kt
+++ b/experimentation/src/main/java/com/automattic/android/experimentation/ExPlat.kt
@@ -25,15 +25,11 @@ public class ExPlat internal constructor(
 
     private var anonymousId: String? = null
 
-    init {
+    override fun initialize(anonymousId: String) {
+        this.anonymousId = anonymousId
         coroutineScope.launch {
             refresh()
         }
-    }
-
-    override fun configure(anonymousId: String?) {
-        clear()
-        this.anonymousId = anonymousId
     }
 
     override fun getVariation(experiment: Experiment): Variation {
@@ -75,7 +71,8 @@ public class ExPlat internal constructor(
         val cachedAssignments: Assignments? = repository.getCached()
         if (refreshStrategy == ALWAYS ||
             cachedAssignments == null ||
-            (refreshStrategy == IF_STALE && assignmentsValidator.isStale(cachedAssignments))
+            (refreshStrategy == IF_STALE && assignmentsValidator.isStale(cachedAssignments)) ||
+            cachedAssignments.anonymousId != anonymousId
         ) {
             coroutineScope.launch { fetchAssignments() }
         }

--- a/experimentation/src/main/java/com/automattic/android/experimentation/ExPlat.kt
+++ b/experimentation/src/main/java/com/automattic/android/experimentation/ExPlat.kt
@@ -69,7 +69,7 @@ public class ExPlat internal constructor(
 
     private fun getAssignments(): Assignments? = repository.getCached()
 
-    private fun invalidateCache(): Assignments? {
+    private fun invalidateCache() {
         val cachedAssignments: Assignments? = repository.getCached()
         if (cachedAssignments == null ||
             assignmentsValidator.isStale(cachedAssignments) ||
@@ -77,7 +77,6 @@ public class ExPlat internal constructor(
         ) {
             coroutineScope.launch { fetchAssignments() }
         }
-        return cachedAssignments
     }
 
     private suspend fun fetchAssignments() {

--- a/experimentation/src/main/java/com/automattic/android/experimentation/ExperimentLogger.kt
+++ b/experimentation/src/main/java/com/automattic/android/experimentation/ExperimentLogger.kt
@@ -2,5 +2,5 @@ package com.automattic.android.experimentation
 
 public interface ExperimentLogger {
     public fun d(message: String)
-    public fun e(message: String, throwable: Throwable)
+    public fun e(message: String, throwable: Throwable? = null)
 }

--- a/experimentation/src/main/java/com/automattic/android/experimentation/VariationsRepository.kt
+++ b/experimentation/src/main/java/com/automattic/android/experimentation/VariationsRepository.kt
@@ -36,11 +36,6 @@ public interface VariationsRepository {
     public fun getVariation(experiment: Experiment): Variation
 
     /**
-     * Refreshes the [Assignments] from the server.
-     */
-    public fun refresh(force: Boolean = false)
-
-    /**
      * Clears the [VariationsRepository] state. This will clear "active" [Variation]s.
      * See [getVariation] for more details.
      */

--- a/experimentation/src/main/java/com/automattic/android/experimentation/VariationsRepository.kt
+++ b/experimentation/src/main/java/com/automattic/android/experimentation/VariationsRepository.kt
@@ -22,7 +22,7 @@ public interface VariationsRepository {
      * Configures the [VariationsRepository] with an anonymous identifier.
      * This identifier is used to fetch the [Assignments] from the server.
      */
-    public fun configure(anonId: String? = null)
+    public fun configure(anonymousId: String? = null)
 
     /**
      * Returns a [Variation] for the provided [Experiment]. [Variation] is then considered "active".
@@ -62,23 +62,22 @@ public interface VariationsRepository {
             platform: String,
             experiments: Set<Experiment>,
             logger: ExperimentLogger,
-            coroutineScope: CoroutineScope,
-            dispatcher: CoroutineDispatcher = Dispatchers.IO,
             isDebug: Boolean,
             cacheDir: File,
+            coroutineScope: CoroutineScope,
+            dispatcher: CoroutineDispatcher = Dispatchers.IO,
         ): ExPlat {
-            val restClient = ExperimentRestClient(dispatcher = dispatcher)
-            val cache = FileBasedCache(cacheDir, dispatcher = dispatcher, scope = coroutineScope)
-            val assignmentsRepository = AssignmentsRepository(restClient, cache)
-            val assignmentsValidator = AssignmentsValidator(SystemClock())
             return ExPlat(
                 platform = platform,
                 experiments = experiments,
                 logger = logger,
                 coroutineScope = coroutineScope,
                 isDebug = isDebug,
-                assignmentsValidator = assignmentsValidator,
-                repository = assignmentsRepository,
+                assignmentsValidator = AssignmentsValidator(SystemClock()),
+                repository = AssignmentsRepository(
+                    ExperimentRestClient(dispatcher = dispatcher),
+                    FileBasedCache(cacheDir, dispatcher = dispatcher, scope = coroutineScope)
+                ),
             )
         }
     }

--- a/experimentation/src/main/java/com/automattic/android/experimentation/VariationsRepository.kt
+++ b/experimentation/src/main/java/com/automattic/android/experimentation/VariationsRepository.kt
@@ -19,15 +19,15 @@ import java.io.File
  */
 public interface VariationsRepository {
     /**
-     * Configures the [VariationsRepository] with an anonymous identifier.
+     * Initializes the [VariationsRepository] with an anonymous identifier.
      * This identifier is used to fetch the [Assignments] from the server.
      */
-    public fun configure(anonymousId: String? = null)
+    public fun initialize(anonymousId: String)
 
     /**
      * Returns a [Variation] for the provided [Experiment]. [Variation] is then considered "active".
      *
-     * Subsequent calls to this method with the same [Experiment] will return the same "active" [Variation] until [clear] or [configure] is called.
+     * Subsequent calls to this method with the same [Experiment] will return the same "active" [Variation] until [clear] or is called.
      * This is a safety mechanism that prevents mixing [Variation] during the same session as this might lead to unexpected behavior.
      *
      * @param experiment [Experiment] for which to get the [Variation]. Must be included in the set provided via [create].
@@ -76,7 +76,7 @@ public interface VariationsRepository {
                 assignmentsValidator = AssignmentsValidator(SystemClock()),
                 repository = AssignmentsRepository(
                     ExperimentRestClient(dispatcher = dispatcher),
-                    FileBasedCache(cacheDir, dispatcher = dispatcher, scope = coroutineScope)
+                    FileBasedCache(cacheDir, dispatcher = dispatcher, scope = coroutineScope),
                 ),
             )
         }

--- a/experimentation/src/main/java/com/automattic/android/experimentation/VariationsRepository.kt
+++ b/experimentation/src/main/java/com/automattic/android/experimentation/VariationsRepository.kt
@@ -50,14 +50,14 @@ public interface VariationsRepository {
          * @param logger to log errors and debug information.
          * @param coroutineScope to use for async operations. Preferably a [CoroutineScope] that is tied to the lifecycle of the application.
          * @param dispatcher to use for async I/O operations. Defaults to [Dispatchers.IO].
-         * @param isDebug If `true`, [getVariation] will throw an [IllegalArgumentException] if the provided [Experiment] is not found.
+         * @param failFast If `true`, [getVariation] will throw exceptions if the [VariationsRepository] is not initialized or if the [Experiment] is not found.
          * @param cacheDir Directory to use for caching the [Assignments]. This directory should be private to the application.
          */
         public fun create(
             platform: String,
             experiments: Set<Experiment>,
             logger: ExperimentLogger,
-            isDebug: Boolean,
+            failFast: Boolean,
             cacheDir: File,
             coroutineScope: CoroutineScope,
             dispatcher: CoroutineDispatcher = Dispatchers.IO,
@@ -67,7 +67,7 @@ public interface VariationsRepository {
                 experiments = experiments,
                 logger = logger,
                 coroutineScope = coroutineScope,
-                isDebug = isDebug,
+                failFast = failFast,
                 assignmentsValidator = AssignmentsValidator(SystemClock()),
                 repository = AssignmentsRepository(
                     ExperimentRestClient(dispatcher = dispatcher),

--- a/experimentation/src/main/java/com/automattic/android/experimentation/domain/Assignments.kt
+++ b/experimentation/src/main/java/com/automattic/android/experimentation/domain/Assignments.kt
@@ -1,6 +1,6 @@
 package com.automattic.android.experimentation.domain
 
-public data class Assignments(
+internal data class Assignments(
     val variations: Map<String, Variation>,
     val timeToLive: Int,
     val fetchedAt: Long,

--- a/experimentation/src/main/java/com/automattic/android/experimentation/domain/Assignments.kt
+++ b/experimentation/src/main/java/com/automattic/android/experimentation/domain/Assignments.kt
@@ -4,4 +4,5 @@ public data class Assignments(
     val variations: Map<String, Variation>,
     val timeToLive: Int,
     val fetchedAt: Long,
+    val anonymousId: String,
 )

--- a/experimentation/src/main/java/com/automattic/android/experimentation/local/CacheDto.kt
+++ b/experimentation/src/main/java/com/automattic/android/experimentation/local/CacheDto.kt
@@ -1,0 +1,15 @@
+package com.automattic.android.experimentation.local
+
+import com.automattic.android.experimentation.remote.AssignmentsDto
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+internal class CacheDto(
+    @Json(name = "assignmentsDto")
+    val assignmentsDto: AssignmentsDto,
+    @Json(name = "fetchedAt")
+    val fetchedAt: Long,
+    @Json(name = "anonymousId")
+    val anonymousId: String,
+)

--- a/experimentation/src/main/java/com/automattic/android/experimentation/local/FileBasedCache.kt
+++ b/experimentation/src/main/java/com/automattic/android/experimentation/local/FileBasedCache.kt
@@ -1,7 +1,6 @@
 package com.automattic.android.experimentation.local
 
 import com.automattic.android.experimentation.domain.Assignments
-import com.automattic.android.experimentation.remote.AssignmentsDtoJsonAdapter
 import com.automattic.android.experimentation.remote.AssignmentsDtoMapper.toAssignments
 import com.automattic.android.experimentation.remote.AssignmentsDtoMapper.toDto
 import com.squareup.moshi.Moshi
@@ -15,7 +14,7 @@ import java.io.File
 internal class FileBasedCache(
     cacheDir: File,
     private val moshi: Moshi = Moshi.Builder().build(),
-    private val jsonAdapter: AssignmentsDtoJsonAdapter = AssignmentsDtoJsonAdapter(moshi),
+    private val cacheDtoJsonAdapter: CacheDtoJsonAdapter = CacheDtoJsonAdapter(moshi),
     private val dispatcher: CoroutineDispatcher,
     scope: CoroutineScope,
 ) {
@@ -42,25 +41,20 @@ internal class FileBasedCache(
 
     suspend fun getAssignments(): Assignments? {
         return withContext(dispatcher) {
-            assignmentsFile.takeIf { it.exists() }?.readText()?.let { json ->
-                val fromJson = wrapperAdapter.fromJson(json) ?: return@let null
+            assignmentsFile.takeIf { it.exists() }?.readText()?.let { json: String ->
+                val fromJson = cacheDtoJsonAdapter.fromJson(json) ?: return@let null
 
-                val (fetchedAt, dtoJson) = fromJson.toList().first()
-
-                val dto = jsonAdapter.fromJson(dtoJson)
-
-                dto?.toAssignments(fetchedAt)
+                fromJson.assignmentsDto.toAssignments(fromJson.fetchedAt, fromJson.anonymousId)
             }
         }
     }
 
     suspend fun saveAssignments(assignments: Assignments) {
         withContext(dispatcher) {
-            val (dto, fetchedAt) = assignments.toDto()
-            val dtoJson = jsonAdapter.serializeNulls().toJson(dto)
+            val cacheDto: CacheDto = assignments.toDto()
+            val dtoJson = cacheDtoJsonAdapter.serializeNulls().toJson(cacheDto)
 
-            val wrapperJson = wrapperAdapter.toJson(mapOf(fetchedAt to dtoJson))
-            assignmentsFile.writeText(wrapperJson)
+            assignmentsFile.writeText(dtoJson)
 
             latestMutable = assignments
         }

--- a/experimentation/src/main/java/com/automattic/android/experimentation/local/FileBasedCache.kt
+++ b/experimentation/src/main/java/com/automattic/android/experimentation/local/FileBasedCache.kt
@@ -44,7 +44,10 @@ internal class FileBasedCache(
             assignmentsFile.takeIf { it.exists() }?.readText()?.let { json: String ->
                 val fromJson = cacheDtoJsonAdapter.fromJson(json) ?: return@let null
 
-                fromJson.assignmentsDto.toAssignments(fromJson.fetchedAt, fromJson.anonymousId)
+                fromJson.assignmentsDto.toAssignments(
+                    fetchedAt = fromJson.fetchedAt,
+                    anonymousId = fromJson.anonymousId,
+                )
             }
         }
     }

--- a/experimentation/src/main/java/com/automattic/android/experimentation/remote/AssignmentsDtoMapper.kt
+++ b/experimentation/src/main/java/com/automattic/android/experimentation/remote/AssignmentsDtoMapper.kt
@@ -2,10 +2,11 @@ package com.automattic.android.experimentation.remote
 
 import com.automattic.android.experimentation.domain.Assignments
 import com.automattic.android.experimentation.domain.Variation
+import com.automattic.android.experimentation.local.CacheDto
 
 internal object AssignmentsDtoMapper {
     private const val CONTROL = "control"
-    fun AssignmentsDto.toAssignments(fetchedAt: Long): Assignments {
+    fun AssignmentsDto.toAssignments(fetchedAt: Long, anonymousId: String): Assignments {
         return Assignments(
             variations = variations.mapValues { (_, value) ->
                 // API returns null for control group, but a previous implementation (back from FluxC)
@@ -18,17 +19,22 @@ internal object AssignmentsDtoMapper {
             },
             timeToLive = ttl,
             fetchedAt = fetchedAt,
+            anonymousId = anonymousId,
         )
     }
-    fun Assignments.toDto(): Pair<AssignmentsDto, Long> {
-        return AssignmentsDto(
-            variations = variations.mapValues { (_, value) ->
-                when (value) {
-                    is Variation.Control -> CONTROL
-                    is Variation.Treatment -> value.name
-                }
-            },
-            ttl = timeToLive,
-        ) to fetchedAt
+    fun Assignments.toDto(): CacheDto {
+        return CacheDto(
+            assignmentsDto = AssignmentsDto(
+                variations = variations.mapValues { (_, value) ->
+                    when (value) {
+                        is Variation.Control -> CONTROL
+                        is Variation.Treatment -> value.name
+                    }
+                },
+                ttl = timeToLive,
+            ),
+            fetchedAt = fetchedAt,
+            anonymousId = anonymousId,
+        )
     }
 }

--- a/experimentation/src/main/java/com/automattic/android/experimentation/remote/ExperimentRestClient.kt
+++ b/experimentation/src/main/java/com/automattic/android/experimentation/remote/ExperimentRestClient.kt
@@ -39,7 +39,10 @@ internal class ExperimentRestClient(
                 } else {
                     runCatching {
                         val dto = jsonAdapter.fromJson(response.body!!.source())!!
-                        dto.toAssignments(clock.currentTimeSeconds())
+                        dto.toAssignments(
+                            fetchedAt = clock.currentTimeSeconds(),
+                            anonymousId = anonymousId!!,
+                        )
                     }
                 }
             }

--- a/experimentation/src/main/java/com/automattic/android/experimentation/remote/ExperimentRestClient.kt
+++ b/experimentation/src/main/java/com/automattic/android/experimentation/remote/ExperimentRestClient.kt
@@ -23,7 +23,7 @@ internal class ExperimentRestClient(
     suspend fun fetchAssignments(
         platform: String,
         experimentNames: List<String>,
-        anonymousId: String? = null,
+        anonymousId: String,
     ): Result<Assignments> {
         val url = urlBuilder.buildUrl(platform, experimentNames, anonymousId)
 
@@ -41,7 +41,7 @@ internal class ExperimentRestClient(
                         val dto = jsonAdapter.fromJson(response.body!!.source())!!
                         dto.toAssignments(
                             fetchedAt = clock.currentTimeSeconds(),
-                            anonymousId = anonymousId!!,
+                            anonymousId = anonymousId,
                         )
                     }
                 }

--- a/experimentation/src/main/java/com/automattic/android/experimentation/repository/AssignmentsRepository.kt
+++ b/experimentation/src/main/java/com/automattic/android/experimentation/repository/AssignmentsRepository.kt
@@ -12,7 +12,7 @@ internal class AssignmentsRepository(
     suspend fun fetch(
         platform: String,
         experimentNames: List<String>,
-        anonymousId: String? = null,
+        anonymousId: String,
     ): Result<Assignments> {
         val fetchResult =
             experimentRestClient.fetchAssignments(platform, experimentNames, anonymousId)

--- a/experimentation/src/test/java/com/automattic/android/experimentation/ExPlatTest.kt
+++ b/experimentation/src/test/java/com/automattic/android/experimentation/ExPlatTest.kt
@@ -22,7 +22,6 @@ import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.Test
 import kotlin.io.path.createTempDirectory
-import kotlinx.coroutines.test.advanceUntilIdle
 
 @ExperimentalCoroutinesApi
 internal class ExPlatTest {
@@ -91,7 +90,7 @@ internal class ExPlatTest {
             val exPlat = createExPlat(clock = { 3601 }, init = { })
             enqueueSuccessfulNetworkResponse(variation = Treatment("variation2"))
             tempCache.saveAssignments(
-                testAssignment.copy(mapOf(testExperimentName to Control), fetchedAt = 0, timeToLive = 3600)
+                testAssignment.copy(mapOf(testExperimentName to Control), fetchedAt = 0, timeToLive = 3600),
             )
             exPlat.initialize(anonymousId)
             val firstGet = exPlat.getVariation(testExperiment)
@@ -135,7 +134,7 @@ internal class ExPlatTest {
             enqueueSuccessfulNetworkResponse(variation = Treatment("variation2"))
             val exPlat = createExPlat(init = { })
             tempCache.saveAssignments(
-                testAssignment.copy(mapOf(testExperimentName to Control), fetchedAt = 0)
+                testAssignment.copy(mapOf(testExperimentName to Control), fetchedAt = 0),
             )
 
             exPlat.initialize("newId")
@@ -147,7 +146,7 @@ internal class ExPlatTest {
                     3600,
                     0,
                     "newId",
-                )
+                ),
             )
         }
 

--- a/experimentation/src/test/java/com/automattic/android/experimentation/ExPlatTest.kt
+++ b/experimentation/src/test/java/com/automattic/android/experimentation/ExPlatTest.kt
@@ -101,7 +101,10 @@ internal class ExPlatTest {
     @Test
     fun `getting variation for the second time returns the same value, even if cache was updated`() =
         runTest {
-            val exPlat = createExPlat(clock = { 123 }).apply { clear() }
+            val exPlat = createExPlat(clock = { 123 }).apply {
+                clear()
+                runCurrent()
+            }
             enqueueSuccessfulNetworkResponse(variation = Treatment("variation2"))
             tempCache.saveAssignments(
                 testAssignment.copy(
@@ -144,10 +147,12 @@ internal class ExPlatTest {
     private val testVariationName = "testVariation"
     private val testExperiment = Experiment(identifier = testExperimentName)
     private val testVariation = Treatment(testVariationName)
+    private val anonymousId = "id"
     private val testAssignment = Assignments(
         variations = mapOf(testExperimentName to testVariation),
         timeToLive = 3600,
         fetchedAt = 0L,
+        anonymousId = anonymousId,
     )
 
     private fun TestScope.createExPlat(

--- a/experimentation/src/test/java/com/automattic/android/experimentation/ExPlatTest.kt
+++ b/experimentation/src/test/java/com/automattic/android/experimentation/ExPlatTest.kt
@@ -150,6 +150,16 @@ internal class ExPlatTest {
             )
         }
 
+    @Test
+    fun `getting variations without initializing throws an exception`() = runTest {
+        val exPlat = createExPlat(init = { })
+
+        assertThatThrownBy {
+            exPlat.getVariation(testExperiment)
+        }.isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("anonymousId is null")
+    }
+
     private val testExperimentName = "testExperiment"
     private val testVariationName = "testVariation"
     private val testExperiment = Experiment(identifier = testExperimentName)

--- a/experimentation/src/test/java/com/automattic/android/experimentation/ExPlatTest.kt
+++ b/experimentation/src/test/java/com/automattic/android/experimentation/ExPlatTest.kt
@@ -202,7 +202,7 @@ internal class ExPlatTest {
                 override fun e(message: String, throwable: Throwable?) = Unit
             },
             coroutineScope = coroutineScope,
-            isDebug = true,
+            failFast = true,
             assignmentsValidator = AssignmentsValidator(clock = clock),
             repository = AssignmentsRepository(restClient, tempCache),
         ).apply(init)

--- a/experimentation/src/test/java/com/automattic/android/experimentation/ExPlatTest.kt
+++ b/experimentation/src/test/java/com/automattic/android/experimentation/ExPlatTest.kt
@@ -22,6 +22,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.Test
 import kotlin.io.path.createTempDirectory
+import kotlinx.coroutines.test.advanceUntilIdle
 
 @ExperimentalCoroutinesApi
 internal class ExPlatTest {
@@ -30,23 +31,23 @@ internal class ExPlatTest {
     private lateinit var tempCache: FileBasedCache
 
     @Test
-    fun `refreshing in case of empty cache is successful`() = runTest {
+    fun `initializing in case of empty cache is fetches assignments`() = runTest {
         enqueueSuccessfulNetworkResponse()
-        val exPlat = createExPlat()
+        val exPlat = createExPlat(init = {})
 
-        exPlat.refresh()
+        exPlat.initialize(anonymousId)
         runCurrent()
 
         assertThat(tempCache.latest).isEqualTo(testAssignment)
     }
 
     @Test
-    fun `refreshing in case of stale cache is successful`() = runTest {
+    fun `initializing in case of stale cache updates it`() = runTest {
         enqueueSuccessfulNetworkResponse()
-        val exPlat = createExPlat(clock = { 3601 })
+        val exPlat = createExPlat(clock = { 3601 }, init = { })
         tempCache.saveAssignments(testAssignment.copy(timeToLive = 3600, fetchedAt = 0))
 
-        exPlat.refresh()
+        exPlat.initialize(anonymousId)
         runCurrent()
 
         assertThat(tempCache.latest).isEqualTo(
@@ -55,30 +56,16 @@ internal class ExPlatTest {
     }
 
     @Test
-    fun `refreshing in case of fresh cache doesn't fetch new assignments`() = runTest {
+    fun `initializing in case of fresh cache doesn't fetch new assignments`() = runTest {
         enqueueSuccessfulNetworkResponse()
-        val exPlat = createExPlat(clock = { 3599 })
+        val exPlat = createExPlat(clock = { 3599 }, init = { })
         tempCache.saveAssignments(testAssignment.copy(timeToLive = 3600))
 
-        exPlat.refresh()
+        exPlat.initialize(anonymousId)
         runCurrent()
 
         assertThat(tempCache.latest).isEqualTo(
             testAssignment,
-        )
-    }
-
-    @Test
-    fun `force refreshing fetches new assignments, even if cache is fresh`() = runTest {
-        enqueueSuccessfulNetworkResponse()
-        val exPlat = createExPlat(clock = { 3599 })
-        tempCache.saveAssignments(testAssignment.copy(timeToLive = 3600))
-
-        exPlat.refresh(force = true)
-        runCurrent()
-
-        assertThat(tempCache.latest).isEqualTo(
-            testAssignment.copy(fetchedAt = 3599),
         )
     }
 
@@ -101,19 +88,17 @@ internal class ExPlatTest {
     @Test
     fun `getting variation for the second time returns the same value, even if cache was updated`() =
         runTest {
-            val exPlat = createExPlat(clock = { 123 }, init = { })
+            val exPlat = createExPlat(clock = { 3601 }, init = { })
             enqueueSuccessfulNetworkResponse(variation = Treatment("variation2"))
             tempCache.saveAssignments(
-                testAssignment.copy(
-                    mapOf(testExperimentName to Control),
-                    fetchedAt = 0,
-                ),
+                testAssignment.copy(mapOf(testExperimentName to Control), fetchedAt = 0, timeToLive = 3600)
             )
+            exPlat.initialize(anonymousId)
             val firstGet = exPlat.getVariation(testExperiment)
-            exPlat.refresh(force = true)
-            runCurrent()
+            runCurrent() // performs fetch from initialization
 
             val secondGet = exPlat.getVariation(testExperiment)
+            runCurrent()
 
             // Even though the cache was updated...
             assertThat(tempCache.latest!!.variations[testExperimentName]).isEqualTo(Treatment("variation2"))
@@ -182,6 +167,7 @@ internal class ExPlatTest {
         clock: Clock = Clock { 0 },
         experiments: Set<Experiment> = setOf(testExperiment),
         init: ExPlat.() -> Unit = {
+            enqueueSuccessfulNetworkResponse()
             initialize(anonymousId)
             runCurrent()
         },
@@ -199,7 +185,6 @@ internal class ExPlatTest {
             scope = coroutineScope,
         )
 
-        enqueueSuccessfulNetworkResponse()
         return ExPlat(
             platform = platform,
             experiments = experiments,

--- a/experimentation/src/test/java/com/automattic/android/experimentation/local/FileBasedCacheTest.kt
+++ b/experimentation/src/test/java/com/automattic/android/experimentation/local/FileBasedCacheTest.kt
@@ -73,6 +73,7 @@ internal class FileBasedCacheTest {
             ),
             timeToLive = 3600,
             fetchedAt = 123456789L,
+            anonymousId = "id",
         )
     }
 }

--- a/experimentation/src/test/java/com/automattic/android/experimentation/remote/AssignmentsDtoMapperTest.kt
+++ b/experimentation/src/test/java/com/automattic/android/experimentation/remote/AssignmentsDtoMapperTest.kt
@@ -29,9 +29,10 @@ class AssignmentsDtoMapperTest {
             ),
             timeToLive = ttl,
             fetchedAt = fetchedAt,
+            anonymousId = "anonymousId",
         )
 
-        val result = dto.toAssignments(fetchedAt)
+        val result = dto.toAssignments(fetchedAt, anonymousId = "anonymousId")
 
         assertEquals(expected, result)
     }

--- a/experimentation/src/test/java/com/automattic/android/experimentation/remote/ExperimentRestClientTest.kt
+++ b/experimentation/src/test/java/com/automattic/android/experimentation/remote/ExperimentRestClientTest.kt
@@ -33,10 +33,11 @@ internal class ExperimentRestClientTest {
                 ),
                 timeToLive = 3600,
                 fetchedAt = TEST_TIMESTAMP,
+                anonymousId = "id",
             ),
         )
 
-        val result = sut.fetchAssignments("", emptyList())
+        val result = sut.fetchAssignments("", emptyList(), anonymousId = "id")
 
         assertEquals(expectedResponse, result)
     }

--- a/experimentation/src/test/java/com/automattic/android/experimentation/remote/ExperimentRestClientTest.kt
+++ b/experimentation/src/test/java/com/automattic/android/experimentation/remote/ExperimentRestClientTest.kt
@@ -48,7 +48,7 @@ internal class ExperimentRestClientTest {
         val errorCode = 503
         server.enqueue(MockResponse().setResponseCode(errorCode))
 
-        val result = sut.fetchAssignments("", emptyList())
+        val result = sut.fetchAssignments("", emptyList(), "")
 
         assertTrue(result.isFailure)
         assertTrue(result.exceptionOrNull()!!.message!!.contains("$errorCode"))
@@ -59,7 +59,7 @@ internal class ExperimentRestClientTest {
         val sut = buildSut(this)
         server.enqueue(MockResponse().setResponseCode(200).setBody("unexpected response"))
 
-        val result = sut.fetchAssignments("", emptyList())
+        val result = sut.fetchAssignments("", emptyList(), "")
 
         assertTrue(result.isFailure)
     }

--- a/sampletracksapp/src/main/java/com/example/sampletracksapp/ExperimentationDialogFragment.kt
+++ b/sampletracksapp/src/main/java/com/example/sampletracksapp/ExperimentationDialogFragment.kt
@@ -70,7 +70,7 @@ class ExperimentationDialogFragment : DialogFragment() {
                     }?.toSet().orEmpty(),
                     cacheDir = cacheDir,
                     coroutineScope = coroutineScope,
-                    isDebug = true,
+                    failFast = true,
                     logger = object : ExperimentLogger {
                         override fun d(message: String) {
                             log(coroutineScope, message)

--- a/sampletracksapp/src/main/java/com/example/sampletracksapp/ExperimentationDialogFragment.kt
+++ b/sampletracksapp/src/main/java/com/example/sampletracksapp/ExperimentationDialogFragment.kt
@@ -55,14 +55,14 @@ class ExperimentationDialogFragment : DialogFragment() {
             coroutineScope.launch {
                 exPlat.collect { exPlat ->
                     withContext(Dispatchers.Main) {
-                        arrayOf(fetch, generateAnonId, clearCache).forEach {
+                        arrayOf(getVariations, generateAnonId, clear).forEach {
                             it.isEnabled = exPlat != null
                         }
                     }
                 }
             }
 
-            setup.setOnClickListener {
+            initialize.setOnClickListener {
                 exPlat.value = VariationsRepository.create(
                     platform = platform.text.toString(),
                     experiments = experiments.text?.toString()?.split(",")?.map {
@@ -85,8 +85,12 @@ class ExperimentationDialogFragment : DialogFragment() {
                 }
             }
 
-            fetch.setOnClickListener {
-                exPlat.value?.refresh(force = true)
+            getVariations.setOnClickListener {
+                experiments.text?.toString()?.split(",")?.forEach { experiment ->
+                    exPlat.value?.getVariation(Experiment(identifier = experiment)).let { variation ->
+                        log(coroutineScope, "$experiment: $variation")
+                    }
+                }
             }
 
             // Implementation detail. This is not a part of the SDK, used here for testing purposes.
@@ -108,10 +112,9 @@ class ExperimentationDialogFragment : DialogFragment() {
 
             generateAnonId.setOnClickListener {
                 anonId.setText(UUID.randomUUID().toString())
-                exPlat.value?.initialize(anonId.text.toString())
             }
 
-            clearCache.setOnClickListener {
+            clear.setOnClickListener {
                 exPlat.value?.clear()
             }
 
@@ -157,7 +160,7 @@ class ExperimentationDialogFragment : DialogFragment() {
         }
 
         private fun manageSetupAvailability() {
-            binding.setup.isEnabled = binding.platform.text?.isNotEmpty() == true &&
+            binding.initialize.isEnabled = binding.platform.text?.isNotEmpty() == true &&
                 binding.experiments.text?.isNotEmpty() == true
         }
 

--- a/sampletracksapp/src/main/java/com/example/sampletracksapp/ExperimentationDialogFragment.kt
+++ b/sampletracksapp/src/main/java/com/example/sampletracksapp/ExperimentationDialogFragment.kt
@@ -76,12 +76,12 @@ class ExperimentationDialogFragment : DialogFragment() {
                             log(coroutineScope, message)
                         }
 
-                        override fun e(message: String, throwable: Throwable) {
+                        override fun e(message: String, throwable: Throwable?) {
                             log(coroutineScope, message)
                         }
                     },
                 ).apply {
-                    configure(anonId.text?.toString().orEmpty())
+                    initialize(anonId.text?.toString().orEmpty())
                 }
             }
 
@@ -108,7 +108,7 @@ class ExperimentationDialogFragment : DialogFragment() {
 
             generateAnonId.setOnClickListener {
                 anonId.setText(UUID.randomUUID().toString())
-                exPlat.value?.configure(anonId.text.toString())
+                exPlat.value?.initialize(anonId.text.toString())
             }
 
             clearCache.setOnClickListener {

--- a/sampletracksapp/src/main/res/layout/dialog_experimentation.xml
+++ b/sampletracksapp/src/main/res/layout/dialog_experimentation.xml
@@ -55,21 +55,21 @@
         android:gravity="center_vertical">
 
         <Button
-            android:id="@+id/setup"
+            android:id="@+id/initialize"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_weight="1"
-            android:text="Setup"
+            android:text="Initialize"
             android:textSize="11sp"
             tools:ignore="ButtonStyle" />
 
         <Button
-            android:id="@+id/fetch"
+            android:id="@+id/getVariations"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginStart="4dp"
             android:layout_weight="1"
-            android:text="Fetch"
+            android:text="Get Variations"
             android:textSize="11sp"
             tools:ignore="ButtonStyle" />
 
@@ -91,12 +91,12 @@
             tools:ignore="ButtonStyle" />
 
         <Button
-            android:id="@+id/clearCache"
+            android:id="@+id/clear"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginStart="4dp"
             android:layout_weight="1"
-            android:text="Clear cache"
+            android:text="Clear SDK\n(cache + state)"
             android:textSize="11sp"
             tools:ignore="ButtonStyle" />
 


### PR DESCRIPTION
### Description

After learning that "anon id" is a necessary piece when requesting experiments assignments (internal source: p1725007206945009-slack-C7HH3V5AS), I've decided to update the public contract to reflect this change and inform SDK consumers early, that anon id is necessary (`initialization`) rather than optional (`configure`)

Furthermore, this PR removes `refresh` method. To my understanding, this was leaking implementation detail. We shouldn't bother SDK consumers when and how cache should be updated - the SDK should handle its own cache.

### How to review

I recommend checking this PR commit by commit and check commit descriptions - I've tried to add more context for each change there and tell a story of changes.

### How to test

The changes are covered with automated unit tests. You can run an example app and follow instructions from #241 but it's not necessary - especially as this PR targets a feature branch.