### PR TITLE
Add auth token

### DIFF
--- a/experimentation/api/experimentation.api
+++ b/experimentation/api/experimentation.api
@@ -1,7 +1,7 @@
 public final class com/automattic/android/experimentation/ExPlat : com/automattic/android/experimentation/VariationsRepository {
 	public fun clear ()V
 	public fun getVariation-98D7FEw (Ljava/lang/String;)Lcom/automattic/android/experimentation/domain/Variation;
-	public fun initialize (Ljava/lang/String;)V
+	public fun initialize (Ljava/lang/String;Ljava/lang/String;)V
 }
 
 public final class com/automattic/android/experimentation/Experiment {
@@ -31,12 +31,16 @@ public abstract interface class com/automattic/android/experimentation/Variation
 	public static final field Companion Lcom/automattic/android/experimentation/VariationsRepository$Companion;
 	public abstract fun clear ()V
 	public abstract fun getVariation-98D7FEw (Ljava/lang/String;)Lcom/automattic/android/experimentation/domain/Variation;
-	public abstract fun initialize (Ljava/lang/String;)V
+	public abstract fun initialize (Ljava/lang/String;Ljava/lang/String;)V
 }
 
 public final class com/automattic/android/experimentation/VariationsRepository$Companion {
-	public final fun create (Ljava/lang/String;Ljava/util/Set;Lcom/automattic/android/experimentation/ExperimentLogger;ZLjava/io/File;Lkotlinx/coroutines/CoroutineScope;Lkotlinx/coroutines/CoroutineDispatcher;)Lcom/automattic/android/experimentation/ExPlat;
-	public static synthetic fun create$default (Lcom/automattic/android/experimentation/VariationsRepository$Companion;Ljava/lang/String;Ljava/util/Set;Lcom/automattic/android/experimentation/ExperimentLogger;ZLjava/io/File;Lkotlinx/coroutines/CoroutineScope;Lkotlinx/coroutines/CoroutineDispatcher;ILjava/lang/Object;)Lcom/automattic/android/experimentation/ExPlat;
+	public final fun create (Ljava/lang/String;Ljava/util/Set;Lcom/automattic/android/experimentation/ExperimentLogger;ZLjava/io/File;Lokhttp3/OkHttpClient;Lkotlinx/coroutines/CoroutineScope;Lkotlinx/coroutines/CoroutineDispatcher;)Lcom/automattic/android/experimentation/ExPlat;
+	public static synthetic fun create$default (Lcom/automattic/android/experimentation/VariationsRepository$Companion;Ljava/lang/String;Ljava/util/Set;Lcom/automattic/android/experimentation/ExperimentLogger;ZLjava/io/File;Lokhttp3/OkHttpClient;Lkotlinx/coroutines/CoroutineScope;Lkotlinx/coroutines/CoroutineDispatcher;ILjava/lang/Object;)Lcom/automattic/android/experimentation/ExPlat;
+}
+
+public final class com/automattic/android/experimentation/VariationsRepository$DefaultImpls {
+	public static synthetic fun initialize$default (Lcom/automattic/android/experimentation/VariationsRepository;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)V
 }
 
 public abstract class com/automattic/android/experimentation/domain/Variation {

--- a/experimentation/src/main/java/com/automattic/android/experimentation/ExPlat.kt
+++ b/experimentation/src/main/java/com/automattic/android/experimentation/ExPlat.kt
@@ -21,9 +21,14 @@ public class ExPlat internal constructor(
     private val experimentIdentifiers: List<String> = experiments.map { it.identifier }
 
     private var anonymousId: String? = null
+    private var oAuthToken: String? = null
 
-    override fun initialize(anonymousId: String) {
+    override fun initialize(
+        anonymousId: String,
+        oAuthToken: String?,
+    ) {
         this.anonymousId = anonymousId
+        this.oAuthToken = oAuthToken
         invalidateCache()
     }
 
@@ -64,6 +69,7 @@ public class ExPlat internal constructor(
         logger.d("ExPlat: clearing cached assignments and active variations")
         activeVariations.clear()
         anonymousId = null
+        oAuthToken = null
         coroutineScope.launch { repository.clearCache() }
     }
 
@@ -82,7 +88,7 @@ public class ExPlat internal constructor(
 
     private suspend fun fetchAssignments() {
         anonymousId?.let { anonymousId ->
-            repository.fetch(platform, experimentIdentifiers, anonymousId).fold(
+            repository.fetch(platform, experimentIdentifiers, anonymousId, oAuthToken).fold(
                 onSuccess = {
                     logger.d("ExPlat: fetching assignments successful with result: $it")
                 },

--- a/experimentation/src/main/java/com/automattic/android/experimentation/VariationsRepository.kt
+++ b/experimentation/src/main/java/com/automattic/android/experimentation/VariationsRepository.kt
@@ -10,6 +10,7 @@ import com.automattic.android.experimentation.repository.AssignmentsRepository
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import okhttp3.OkHttpClient
 import java.io.File
 
 /**
@@ -51,10 +52,11 @@ public interface VariationsRepository {
          * @param platform The platform identifier. See ExPlat documentation for more details.
          * @param experiments Set of [Experiment]s to be used by the [VariationsRepository].
          * @param logger to log errors and debug information.
-         * @param coroutineScope to use for async operations. Preferably a [CoroutineScope] that is tied to the lifecycle of the application.
-         * @param dispatcher to use for async I/O operations. Defaults to [Dispatchers.IO].
          * @param failFast If `true`, [getVariation] will throw exceptions if the [VariationsRepository] is not initialized or if the [Experiment] is not found.
          * @param cacheDir Directory to use for caching the [Assignments]. This directory should be private to the application.
+         * @param okhttpClient to use for network operations. Defaults to a new instance of [OkHttpClient].
+         * @param coroutineScope to use for async operations. Preferably a [CoroutineScope] that is tied to the lifecycle of the application.
+         * @param dispatcher to use for async I/O operations. Defaults to [Dispatchers.IO].
          */
         public fun create(
             platform: String,
@@ -62,6 +64,7 @@ public interface VariationsRepository {
             logger: ExperimentLogger,
             failFast: Boolean,
             cacheDir: File,
+            okhttpClient: OkHttpClient = OkHttpClient(),
             coroutineScope: CoroutineScope,
             dispatcher: CoroutineDispatcher = Dispatchers.IO,
         ): ExPlat {
@@ -73,7 +76,7 @@ public interface VariationsRepository {
                 failFast = failFast,
                 assignmentsValidator = AssignmentsValidator(SystemClock()),
                 repository = AssignmentsRepository(
-                    ExperimentRestClient(dispatcher = dispatcher),
+                    ExperimentRestClient(dispatcher = dispatcher, okHttpClient = okhttpClient),
                     FileBasedCache(cacheDir, dispatcher = dispatcher, scope = coroutineScope),
                 ),
             )

--- a/experimentation/src/main/java/com/automattic/android/experimentation/VariationsRepository.kt
+++ b/experimentation/src/main/java/com/automattic/android/experimentation/VariationsRepository.kt
@@ -19,10 +19,13 @@ import java.io.File
  */
 public interface VariationsRepository {
     /**
-     * Initializes the [VariationsRepository] with an anonymous identifier.
-     * This identifier is used to fetch the [Assignments] from the server.
+     * Initializes the [VariationsRepository].
+     *
+     * @param anonymousId Identifier for the user. This should be unique for each user.
+     * @param oAuthToken Optional OAuth token for the user. This is used to fetch the [Assignments] from the server.
+     *
      */
-    public fun initialize(anonymousId: String)
+    public fun initialize(anonymousId: String, oAuthToken: String? = null)
 
     /**
      * Returns a [Variation] for the provided [Experiment]. [Variation] is then considered "active".

--- a/experimentation/src/main/java/com/automattic/android/experimentation/remote/ExperimentRestClient.kt
+++ b/experimentation/src/main/java/com/automattic/android/experimentation/remote/ExperimentRestClient.kt
@@ -24,11 +24,13 @@ internal class ExperimentRestClient(
         platform: String,
         experimentNames: List<String>,
         anonymousId: String,
+        oAuthToken: String?,
     ): Result<Assignments> {
         val url = urlBuilder.buildUrl(platform, experimentNames, anonymousId)
 
         val request = Request.Builder()
             .url(url)
+            .apply { oAuthToken?.let { header("Authorization ", "Bearer $it") } }
             .get()
             .build()
 

--- a/experimentation/src/main/java/com/automattic/android/experimentation/remote/ExperimentRestClient.kt
+++ b/experimentation/src/main/java/com/automattic/android/experimentation/remote/ExperimentRestClient.kt
@@ -30,7 +30,7 @@ internal class ExperimentRestClient(
 
         val request = Request.Builder()
             .url(url)
-            .apply { oAuthToken?.let { header("Authorization ", "Bearer $it") } }
+            .apply { oAuthToken?.let { header("Authorization", "Bearer $it") } }
             .get()
             .build()
 

--- a/experimentation/src/main/java/com/automattic/android/experimentation/remote/ExperimentRestClient.kt
+++ b/experimentation/src/main/java/com/automattic/android/experimentation/remote/ExperimentRestClient.kt
@@ -12,7 +12,7 @@ import okhttp3.Request
 import java.io.IOException
 
 internal class ExperimentRestClient(
-    private val okHttpClient: OkHttpClient = OkHttpClient(),
+    private val okHttpClient: OkHttpClient,
     private val moshi: Moshi = Moshi.Builder().build(),
     private val jsonAdapter: AssignmentsDtoJsonAdapter = AssignmentsDtoJsonAdapter(moshi),
     private val urlBuilder: UrlBuilder = ExPlatUrlBuilder(),

--- a/experimentation/src/main/java/com/automattic/android/experimentation/repository/AssignmentsRepository.kt
+++ b/experimentation/src/main/java/com/automattic/android/experimentation/repository/AssignmentsRepository.kt
@@ -13,9 +13,10 @@ internal class AssignmentsRepository(
         platform: String,
         experimentNames: List<String>,
         anonymousId: String,
+        oAuthToken: String?,
     ): Result<Assignments> {
         val fetchResult =
-            experimentRestClient.fetchAssignments(platform, experimentNames, anonymousId)
+            experimentRestClient.fetchAssignments(platform, experimentNames, anonymousId, oAuthToken)
 
         return fetchResult.fold(
             onFailure = {

--- a/experimentation/src/test/java/com/automattic/android/experimentation/ExPlatTest.kt
+++ b/experimentation/src/test/java/com/automattic/android/experimentation/ExPlatTest.kt
@@ -16,6 +16,7 @@ import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
+import okhttp3.OkHttpClient
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import org.assertj.core.api.Assertions.assertThat
@@ -187,6 +188,7 @@ internal class ExPlatTest {
             urlBuilder = MockWebServerUrlBuilder(ExPlatUrlBuilder(), server),
             dispatcher = dispatcher,
             clock = clock,
+            okHttpClient = OkHttpClient(),
         )
         tempCache = FileBasedCache(
             createTempDirectory().toFile(),

--- a/experimentation/src/test/java/com/automattic/android/experimentation/remote/ExperimentRestClientTest.kt
+++ b/experimentation/src/test/java/com/automattic/android/experimentation/remote/ExperimentRestClientTest.kt
@@ -37,7 +37,7 @@ internal class ExperimentRestClientTest {
             ),
         )
 
-        val result = sut.fetchAssignments("", emptyList(), anonymousId = "id")
+        val result = sut.fetchAssignments("", emptyList(), anonymousId = "id", oAuthToken = null)
 
         assertEquals(expectedResponse, result)
     }
@@ -48,7 +48,7 @@ internal class ExperimentRestClientTest {
         val errorCode = 503
         server.enqueue(MockResponse().setResponseCode(errorCode))
 
-        val result = sut.fetchAssignments("", emptyList(), "")
+        val result = sut.fetchAssignments("", emptyList(), "", oAuthToken = null)
 
         assertTrue(result.isFailure)
         assertTrue(result.exceptionOrNull()!!.message!!.contains("$errorCode"))
@@ -59,7 +59,7 @@ internal class ExperimentRestClientTest {
         val sut = buildSut(this)
         server.enqueue(MockResponse().setResponseCode(200).setBody("unexpected response"))
 
-        val result = sut.fetchAssignments("", emptyList(), "")
+        val result = sut.fetchAssignments("", emptyList(), "", oAuthToken = null)
 
         assertTrue(result.isFailure)
     }
@@ -78,7 +78,7 @@ internal class ExperimentRestClientTest {
         }
         server.dispatcher = respondOnlyOnAnonIdDispatcher
 
-        val result = sut.fetchAssignments("", emptyList(), "random_id")
+        val result = sut.fetchAssignments("", emptyList(), "random_id", oAuthToken = null)
 
         assertThat(result.getOrNull()!!.variations).isNotEmpty
     }

--- a/experimentation/src/test/java/com/automattic/android/experimentation/remote/ExperimentRestClientTest.kt
+++ b/experimentation/src/test/java/com/automattic/android/experimentation/remote/ExperimentRestClientTest.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
+import okhttp3.OkHttpClient
 import okhttp3.mockwebserver.Dispatcher
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
@@ -87,6 +88,7 @@ internal class ExperimentRestClientTest {
         urlBuilder = MockWebServerUrlBuilder(ExPlatUrlBuilder(), server),
         clock = { TEST_TIMESTAMP },
         dispatcher = StandardTestDispatcher(scope.testScheduler),
+        okHttpClient = OkHttpClient(),
     )
 
     companion object {


### PR DESCRIPTION
### Description

This PR adds a support for providing the oAuthToken when making a request to Experiments API. This token is WPCOM, so it's most likely only useful for Woo/WordPress/Jetpack apps.