### PR TITLE
Create cache parent directories if they don't exist

### DIFF
--- a/experimentation/src/main/java/com/automattic/android/experimentation/VariationsRepository.kt
+++ b/experimentation/src/main/java/com/automattic/android/experimentation/VariationsRepository.kt
@@ -77,7 +77,13 @@ public interface VariationsRepository {
                 assignmentsValidator = AssignmentsValidator(SystemClock()),
                 repository = AssignmentsRepository(
                     ExperimentRestClient(dispatcher = dispatcher, okHttpClient = okhttpClient),
-                    FileBasedCache(cacheDir, dispatcher = dispatcher, scope = coroutineScope),
+                    FileBasedCache(
+                        cacheDir,
+                        dispatcher = dispatcher,
+                        scope = coroutineScope,
+                        logger = logger,
+                        failFast = failFast,
+                    ),
                 ),
             )
         }

--- a/experimentation/src/main/java/com/automattic/android/experimentation/local/FileBasedCache.kt
+++ b/experimentation/src/main/java/com/automattic/android/experimentation/local/FileBasedCache.kt
@@ -4,7 +4,6 @@ import com.automattic.android.experimentation.domain.Assignments
 import com.automattic.android.experimentation.remote.AssignmentsDtoMapper.toAssignments
 import com.automattic.android.experimentation.remote.AssignmentsDtoMapper.toDto
 import com.squareup.moshi.Moshi
-import com.squareup.moshi.Types
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
@@ -20,12 +19,6 @@ internal class FileBasedCache(
 ) {
 
     private val assignmentsFile = File(cacheDir, "assignments.json")
-    private val type = Types.newParameterizedType(
-        Map::class.java,
-        Long::class.javaObjectType,
-        String::class.java,
-    )
-    private val wrapperAdapter = moshi.adapter<Map<Long, String>>(type)
     private var latestMutable: Assignments? = null
 
     internal val latest: Assignments?

--- a/experimentation/src/main/java/com/automattic/android/experimentation/local/FileBasedCache.kt
+++ b/experimentation/src/main/java/com/automattic/android/experimentation/local/FileBasedCache.kt
@@ -47,6 +47,8 @@ internal class FileBasedCache(
 
     suspend fun saveAssignments(assignments: Assignments) {
         withContext(dispatcher) {
+            assignmentsFile.parentFile?.mkdirs()
+
             val cacheDto: CacheDto = assignments.toDto()
             val dtoJson = cacheDtoJsonAdapter.serializeNulls().toJson(cacheDto)
 

--- a/experimentation/src/test/java/com/automattic/android/experimentation/ExPlatTest.kt
+++ b/experimentation/src/test/java/com/automattic/android/experimentation/ExPlatTest.kt
@@ -182,6 +182,10 @@ internal class ExPlatTest {
             runCurrent()
         },
     ): ExPlat {
+        val logger = object : ExperimentLogger {
+            override fun d(message: String) = Unit
+            override fun e(message: String, throwable: Throwable?) = Unit
+        }
         val coroutineScope = this
         val dispatcher = StandardTestDispatcher(coroutineScope.testScheduler)
         val restClient = ExperimentRestClient(
@@ -194,15 +198,14 @@ internal class ExPlatTest {
             createTempDirectory().toFile(),
             dispatcher = dispatcher,
             scope = coroutineScope,
+            logger = logger,
+            failFast = true,
         )
 
         return ExPlat(
             platform = platform,
             experiments = experiments,
-            logger = object : ExperimentLogger {
-                override fun d(message: String) = Unit
-                override fun e(message: String, throwable: Throwable?) = Unit
-            },
+            logger = logger,
             coroutineScope = coroutineScope,
             failFast = true,
             assignmentsValidator = AssignmentsValidator(clock = clock),

--- a/experimentation/src/test/java/com/automattic/android/experimentation/local/FileBasedCacheTest.kt
+++ b/experimentation/src/test/java/com/automattic/android/experimentation/local/FileBasedCacheTest.kt
@@ -3,6 +3,7 @@ package com.automattic.android.experimentation.local
 import com.automattic.android.experimentation.domain.Assignments
 import com.automattic.android.experimentation.domain.Variation.Control
 import com.automattic.android.experimentation.domain.Variation.Treatment
+import java.io.File
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestScope
@@ -59,8 +60,23 @@ internal class FileBasedCacheTest {
         sut.clear()
     }
 
-    private fun fileBasedCache(scope: TestScope) = FileBasedCache(
-        cacheDir = createTempDirectory().toFile(),
+    @Test
+    fun `saving cache when cache dir doesnt exist is successful`() = runTest {
+        val cacheDir = File("build/non-existent").apply { assert(!this.exists()) }
+        val sut = fileBasedCache(this, cacheDir = cacheDir)
+        sut.saveAssignments(TEST_ASSIGNMENTS)
+
+        val result = sut.getAssignments()
+
+        assertEquals(TEST_ASSIGNMENTS, result)
+        cacheDir.deleteRecursively()
+    }
+
+    private fun fileBasedCache(
+        scope: TestScope,
+        cacheDir: File = createTempDirectory().toFile(),
+    ) = FileBasedCache(
+        cacheDir = cacheDir,
         dispatcher = StandardTestDispatcher(scope.testScheduler),
         scope = scope,
     )

--- a/experimentation/src/test/java/com/automattic/android/experimentation/local/FileBasedCacheTest.kt
+++ b/experimentation/src/test/java/com/automattic/android/experimentation/local/FileBasedCacheTest.kt
@@ -1,5 +1,6 @@
 package com.automattic.android.experimentation.local
 
+import com.automattic.android.experimentation.ExperimentLogger
 import com.automattic.android.experimentation.domain.Assignments
 import com.automattic.android.experimentation.domain.Variation.Control
 import com.automattic.android.experimentation.domain.Variation.Treatment
@@ -9,11 +10,11 @@ import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
+import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.TemporaryFolder
 import java.io.File
 import kotlin.io.path.createTempDirectory
-import org.junit.Rule
-import org.junit.rules.TemporaryFolder
 
 @OptIn(ExperimentalCoroutinesApi::class)
 internal class FileBasedCacheTest {
@@ -84,6 +85,11 @@ internal class FileBasedCacheTest {
         cacheDir = cacheDir,
         dispatcher = StandardTestDispatcher(scope.testScheduler),
         scope = scope,
+        logger = object : ExperimentLogger {
+            override fun d(message: String) = Unit
+            override fun e(message: String, throwable: Throwable?) = Unit
+        },
+        failFast = true,
     )
 
     companion object {

--- a/experimentation/src/test/java/com/automattic/android/experimentation/local/FileBasedCacheTest.kt
+++ b/experimentation/src/test/java/com/automattic/android/experimentation/local/FileBasedCacheTest.kt
@@ -7,23 +7,14 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
-import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
-import org.junit.Before
 import org.junit.Test
 import java.io.File
 import kotlin.io.path.createTempDirectory
 
 @OptIn(ExperimentalCoroutinesApi::class)
 internal class FileBasedCacheTest {
-
-    private lateinit var nonExistingCacheDir: File
-
-    @Before
-    fun setUp() {
-        nonExistingCacheDir = File("build/non-existent")
-    }
 
     @Test
     fun `saving and reading assignments is successful`() = runTest {
@@ -71,18 +62,14 @@ internal class FileBasedCacheTest {
 
     @Test
     fun `saving cache when cache dir doesnt exist is successful`() = runTest {
-        nonExistingCacheDir.apply { assert(!this.exists()) }
-        val sut = fileBasedCache(this, cacheDir = nonExistingCacheDir)
+        val cacheDir = File("build/non-existent").apply { assert(!this.exists()) }
+        val sut = fileBasedCache(this, cacheDir = cacheDir)
         sut.saveAssignments(TEST_ASSIGNMENTS)
 
         val result = sut.getAssignments()
 
         assertEquals(TEST_ASSIGNMENTS, result)
-    }
-
-    @After
-    fun tearDown() {
-        nonExistingCacheDir.deleteRecursively()
+        cacheDir.deleteRecursively()
     }
 
     private fun fileBasedCache(

--- a/experimentation/src/test/java/com/automattic/android/experimentation/local/FileBasedCacheTest.kt
+++ b/experimentation/src/test/java/com/automattic/android/experimentation/local/FileBasedCacheTest.kt
@@ -3,7 +3,6 @@ package com.automattic.android.experimentation.local
 import com.automattic.android.experimentation.domain.Assignments
 import com.automattic.android.experimentation.domain.Variation.Control
 import com.automattic.android.experimentation.domain.Variation.Treatment
-import java.io.File
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestScope
@@ -11,6 +10,7 @@ import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Test
+import java.io.File
 import kotlin.io.path.createTempDirectory
 
 @OptIn(ExperimentalCoroutinesApi::class)

--- a/experimentation/src/test/java/com/automattic/android/experimentation/local/FileBasedCacheTest.kt
+++ b/experimentation/src/test/java/com/automattic/android/experimentation/local/FileBasedCacheTest.kt
@@ -12,9 +12,14 @@ import org.junit.Assert.assertNull
 import org.junit.Test
 import java.io.File
 import kotlin.io.path.createTempDirectory
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
 
 @OptIn(ExperimentalCoroutinesApi::class)
 internal class FileBasedCacheTest {
+
+    @get:Rule
+    val tempDir = TemporaryFolder()
 
     @Test
     fun `saving and reading assignments is successful`() = runTest {
@@ -62,7 +67,7 @@ internal class FileBasedCacheTest {
 
     @Test
     fun `saving cache when cache dir doesnt exist is successful`() = runTest {
-        val cacheDir = File("build/non-existent").apply { assert(!this.exists()) }
+        val cacheDir = File(tempDir.newFolder(), "cache").apply { assert(!this.exists()) }
         val sut = fileBasedCache(this, cacheDir = cacheDir)
         sut.saveAssignments(TEST_ASSIGNMENTS)
 

--- a/experimentation/src/test/java/com/automattic/android/experimentation/local/FileBasedCacheTest.kt
+++ b/experimentation/src/test/java/com/automattic/android/experimentation/local/FileBasedCacheTest.kt
@@ -7,14 +7,23 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
+import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
+import org.junit.Before
 import org.junit.Test
 import java.io.File
 import kotlin.io.path.createTempDirectory
 
 @OptIn(ExperimentalCoroutinesApi::class)
 internal class FileBasedCacheTest {
+
+    private lateinit var nonExistingCacheDir: File
+
+    @Before
+    fun setUp() {
+        nonExistingCacheDir = File("build/non-existent")
+    }
 
     @Test
     fun `saving and reading assignments is successful`() = runTest {
@@ -62,14 +71,18 @@ internal class FileBasedCacheTest {
 
     @Test
     fun `saving cache when cache dir doesnt exist is successful`() = runTest {
-        val cacheDir = File("build/non-existent").apply { assert(!this.exists()) }
-        val sut = fileBasedCache(this, cacheDir = cacheDir)
+        nonExistingCacheDir.apply { assert(!this.exists()) }
+        val sut = fileBasedCache(this, cacheDir = nonExistingCacheDir)
         sut.saveAssignments(TEST_ASSIGNMENTS)
 
         val result = sut.getAssignments()
 
         assertEquals(TEST_ASSIGNMENTS, result)
-        cacheDir.deleteRecursively()
+    }
+
+    @After
+    fun tearDown() {
+        nonExistingCacheDir.deleteRecursively()
     }
 
     private fun fileBasedCache(


### PR DESCRIPTION
### Description

This PR adds a behavior of creating parent dirs for a cache file for ExPlat module if needed. This way, client's don't have to worry if directories they provide exist.

### Testing 

Checkout a06f9cf and run added test (to confirm it fails). Or comment out https://github.com/Automattic/Automattic-Tracks-Android/blob/dae98ab49ce3ad3b0e2989541ab572d0eca13fb9/experimentation/src/main/java/com/automattic/android/experimentation/local/FileBasedCache.kt#L50

and see that test fails.