### PR TITLE
Don't crash when ExPlat API request failed

### DIFF
--- a/experimentation/src/main/java/com/automattic/android/experimentation/remote/ExperimentRestClient.kt
+++ b/experimentation/src/main/java/com/automattic/android/experimentation/remote/ExperimentRestClient.kt
@@ -35,18 +35,24 @@ internal class ExperimentRestClient(
             .build()
 
         return withContext(dispatcher) {
-            okHttpClient.newCall(request).execute().use { response ->
-                if (!response.isSuccessful) {
-                    Result.failure(IOException("Unexpected code $response"))
-                } else {
-                    runCatching {
-                        val dto = jsonAdapter.fromJson(response.body!!.source())!!
-                        dto.toAssignments(
-                            fetchedAt = clock.currentTimeSeconds(),
-                            anonymousId = anonymousId,
-                        )
+            try {
+                okHttpClient.newCall(request).execute().use { response ->
+                    if (!response.isSuccessful) {
+                        Result.failure(IOException("Unexpected code $response"))
+                    } else {
+                        runCatching {
+                            val dto = jsonAdapter.fromJson(response.body!!.source())!!
+                            dto.toAssignments(
+                                fetchedAt = clock.currentTimeSeconds(),
+                                anonymousId = anonymousId,
+                            )
+                        }
                     }
                 }
+            } catch (e: IOException) {
+                Result.failure(e)
+            } catch (e: IllegalStateException) {
+                Result.failure(e)
             }
         }
     }

--- a/experimentation/src/test/java/com/automattic/android/experimentation/remote/ExperimentRestClientTest.kt
+++ b/experimentation/src/test/java/com/automattic/android/experimentation/remote/ExperimentRestClientTest.kt
@@ -88,7 +88,7 @@ internal class ExperimentRestClientTest {
     fun `fetching assignments from an unknown host is a failure without crash`() = runTest {
         val sut = buildSut(
             this,
-            UnknownHostMockWebServerUrlBuilder(ExPlatUrlBuilder(), server)
+            UnknownHostMockWebServerUrlBuilder(ExPlatUrlBuilder(), server),
         )
 
         val result = sut.fetchAssignments("", emptyList(), "random_id", oAuthToken = null)
@@ -98,7 +98,7 @@ internal class ExperimentRestClientTest {
 
     private fun buildSut(
         scope: TestScope,
-        urlBuilder: MockWebServerUrlBuilder = MockWebServerUrlBuilder(ExPlatUrlBuilder(), server)
+        urlBuilder: MockWebServerUrlBuilder = MockWebServerUrlBuilder(ExPlatUrlBuilder(), server),
     ) = ExperimentRestClient(
         urlBuilder = urlBuilder,
         clock = { TEST_TIMESTAMP },

--- a/experimentation/src/test/java/com/automattic/android/experimentation/remote/ExperimentRestClientTest.kt
+++ b/experimentation/src/test/java/com/automattic/android/experimentation/remote/ExperimentRestClientTest.kt
@@ -84,8 +84,23 @@ internal class ExperimentRestClientTest {
         assertThat(result.getOrNull()!!.variations).isNotEmpty
     }
 
-    private fun buildSut(scope: TestScope) = ExperimentRestClient(
-        urlBuilder = MockWebServerUrlBuilder(ExPlatUrlBuilder(), server),
+    @Test
+    fun `fetching assignments from an unknown host is a failure without crash`() = runTest {
+        val sut = buildSut(
+            this,
+            UnknownHostMockWebServerUrlBuilder(ExPlatUrlBuilder(), server)
+        )
+
+        val result = sut.fetchAssignments("", emptyList(), "random_id", oAuthToken = null)
+
+        assertThat(result.isFailure).isTrue()
+    }
+
+    private fun buildSut(
+        scope: TestScope,
+        urlBuilder: MockWebServerUrlBuilder = MockWebServerUrlBuilder(ExPlatUrlBuilder(), server)
+    ) = ExperimentRestClient(
+        urlBuilder = urlBuilder,
         clock = { TEST_TIMESTAMP },
         dispatcher = StandardTestDispatcher(scope.testScheduler),
         okHttpClient = OkHttpClient(),

--- a/experimentation/src/test/java/com/automattic/android/experimentation/remote/MockWebServerUrlBuilder.kt
+++ b/experimentation/src/test/java/com/automattic/android/experimentation/remote/MockWebServerUrlBuilder.kt
@@ -27,11 +27,11 @@ internal open class MockWebServerUrlBuilder(
 internal class UnknownHostMockWebServerUrlBuilder(
     exPlatUrlBuilder: ExPlatUrlBuilder,
     server: MockWebServer,
-): MockWebServerUrlBuilder(exPlatUrlBuilder, server){
+) : MockWebServerUrlBuilder(exPlatUrlBuilder, server) {
     override fun buildUrl(
         platform: String,
         experimentNames: List<String>,
-        anonymousId: String?
+        anonymousId: String?,
     ): HttpUrl {
         return super.buildUrl(platform, experimentNames, anonymousId).newBuilder()
             .host("unknownhost")

--- a/experimentation/src/test/java/com/automattic/android/experimentation/remote/MockWebServerUrlBuilder.kt
+++ b/experimentation/src/test/java/com/automattic/android/experimentation/remote/MockWebServerUrlBuilder.kt
@@ -3,7 +3,7 @@ package com.automattic.android.experimentation.remote
 import okhttp3.HttpUrl
 import okhttp3.mockwebserver.MockWebServer
 
-internal class MockWebServerUrlBuilder(
+internal open class MockWebServerUrlBuilder(
     private val exPlatUrlBuilder: ExPlatUrlBuilder,
     private val server: MockWebServer,
 ) : UrlBuilder {
@@ -20,6 +20,21 @@ internal class MockWebServerUrlBuilder(
             .scheme("http")
             .host(server.url("/").host)
             .port(server.url("/").port)
+            .build()
+    }
+}
+
+internal class UnknownHostMockWebServerUrlBuilder(
+    exPlatUrlBuilder: ExPlatUrlBuilder,
+    server: MockWebServer,
+): MockWebServerUrlBuilder(exPlatUrlBuilder, server){
+    override fun buildUrl(
+        platform: String,
+        experimentNames: List<String>,
+        anonymousId: String?
+    ): HttpUrl {
+        return super.buildUrl(platform, experimentNames, anonymousId).newBuilder()
+            .host("unknownhost")
             .build()
     }
 }


### PR DESCRIPTION
### Description

This PR wraps `Call#execute` in `try/catch` to make sure that SDK doesn't crash the app in case of API connection issues. Internal context: p1731543068879949-slack-C07J5LNP4SF

### Testing

1. Cherry out fabe1d7 and assert that the newly added test throws unhandled `UnknownHostException` exception
2. Check out 138df3b, rerun test and see that exception is handled