### PR TITLE
Add Gravatar user type

### DIFF
--- a/AutomatticTracks/src/main/java/com/automattic/android/tracks/MessageBuilder.java
+++ b/AutomatticTracks/src/main/java/com/automattic/android/tracks/MessageBuilder.java
@@ -24,6 +24,7 @@ class MessageBuilder {
     private static final String USER_TYPE_SIMPLENOTE = "simplenote:user_id";
     private static final String USER_TYPE_POCKETCASTS = "pocketcasts:user_id";
     private static final String USER_TYPE_DAYONE = "dayone:user_id";
+    private static final String USER_TYPE_GRAVATAR = "gravatar:user_id";
     private static final String USER_ID_KEY = "_ui";
     private static final String USER_LANG_KEY = "_lg";
     private static final String USER_LOGIN_NAME_KEY = "_ul";
@@ -115,6 +116,11 @@ class MessageBuilder {
                 case DAYONE:
                     eventJSON.put(USER_ID_KEY, event.getUser());
                     eventJSON.put(USER_TYPE_KEY, USER_TYPE_DAYONE);
+                    break;
+            case GRAVATAR:
+                    eventJSON.put(USER_ID_KEY, event.getUser());
+                    eventJSON.put(USER_TYPE_KEY, USER_TYPE_GRAVATAR);
+                    break;
             }
 
             unfolderPropertiesNotAvailableInCommon(event.getUserProperties(), USER_INFO_PREFIX, eventJSON, commonProps);

--- a/AutomatticTracks/src/main/java/com/automattic/android/tracks/TracksClient.java
+++ b/AutomatticTracks/src/main/java/com/automattic/android/tracks/TracksClient.java
@@ -39,7 +39,7 @@ public class TracksClient {
     protected static final int DEFAULT_EVENTS_QUEUE_TIMER_MS = 30000;
     protected static final int DEFAULT_EVENT_MAX_AGE = 14 * 24 * 60 * 60 * 1000 ; // 14 days
 
-    public static enum NosaraUserType {ANON, WPCOM, SIMPLENOTE, POCKETCASTS, DAYONE}
+    public static enum NosaraUserType {ANON, WPCOM, SIMPLENOTE, POCKETCASTS, DAYONE, GRAVATAR}
 
     /**
      * Socket timeout in milliseconds for rest requests


### PR DESCRIPTION
This PR adds the Gravatar user type to use Tracks in the Gravatar application.

I saw in #167 that the user type should be allowed. I've also seen that [is here](https://github.com/Automattic/nosara/blob/f9a09e92b5ae74d41092254230bd4b68e19126e7/ganymedes2/kafka_staging/src/main/resources/tracks/whitelists/tracks_events_whitelist.config#L18) but not sure if I need to do anything. Please let me know 🙏 

Code review should be enough.