### PR TITLE
Revert "Merge pull request #263 from Automattic/hamorillo/gravatar_user_type"

### DIFF
--- a/AutomatticTracks/src/main/java/com/automattic/android/tracks/MessageBuilder.java
+++ b/AutomatticTracks/src/main/java/com/automattic/android/tracks/MessageBuilder.java
@@ -24,7 +24,6 @@ class MessageBuilder {
     private static final String USER_TYPE_SIMPLENOTE = "simplenote:user_id";
     private static final String USER_TYPE_POCKETCASTS = "pocketcasts:user_id";
     private static final String USER_TYPE_DAYONE = "dayone:user_id";
-    private static final String USER_TYPE_GRAVATAR = "gravatar:user_id";
     private static final String USER_ID_KEY = "_ui";
     private static final String USER_LANG_KEY = "_lg";
     private static final String USER_LOGIN_NAME_KEY = "_ul";
@@ -116,11 +115,6 @@ class MessageBuilder {
                 case DAYONE:
                     eventJSON.put(USER_ID_KEY, event.getUser());
                     eventJSON.put(USER_TYPE_KEY, USER_TYPE_DAYONE);
-                    break;
-            case GRAVATAR:
-                    eventJSON.put(USER_ID_KEY, event.getUser());
-                    eventJSON.put(USER_TYPE_KEY, USER_TYPE_GRAVATAR);
-                    break;
             }
 
             unfolderPropertiesNotAvailableInCommon(event.getUserProperties(), USER_INFO_PREFIX, eventJSON, commonProps);

--- a/AutomatticTracks/src/main/java/com/automattic/android/tracks/TracksClient.java
+++ b/AutomatticTracks/src/main/java/com/automattic/android/tracks/TracksClient.java
@@ -39,7 +39,7 @@ public class TracksClient {
     protected static final int DEFAULT_EVENTS_QUEUE_TIMER_MS = 30000;
     protected static final int DEFAULT_EVENT_MAX_AGE = 14 * 24 * 60 * 60 * 1000 ; // 14 days
 
-    public static enum NosaraUserType {ANON, WPCOM, SIMPLENOTE, POCKETCASTS, DAYONE, GRAVATAR}
+    public static enum NosaraUserType {ANON, WPCOM, SIMPLENOTE, POCKETCASTS, DAYONE}
 
     /**
      * Socket timeout in milliseconds for rest requests


### PR DESCRIPTION
After discussing inside the Gravatar team, we realized that we should use the WPCOM `userTypeId` so we don't need to add a new type to the library.  (Sorry for the inconvenience 😖)

This reverts commit c74ea803a5b963c901285e0ac0d2a0c0ffb83e30, reversing changes made to c0193681980308468810a6828882e3742257d3f2.