### PR TITLE
Use `profileSessionSampleRate`

### DIFF
--- a/crashlogging/src/main/java/com/automattic/android/tracks/crashlogging/CrashLoggingDataProvider.kt
+++ b/crashlogging/src/main/java/com/automattic/android/tracks/crashlogging/CrashLoggingDataProvider.kt
@@ -116,6 +116,19 @@ sealed class PerformanceMonitoringConfig {
          * Mind that this value is **relative** to [sampleRate] value.
          * Has to be between 0 and 1.
          */
+        @Deprecated(
+            "Use [profileSessionSampleRate] instead. This configuration option is no longer used.",
+            level = DeprecationLevel.HIDDEN
+        )
+        val profilesSampleRate: Double = 0.0,
+        /**
+         * Provides sample rate for recording profiles.
+         * Indicates how often a profiling session is recorded.
+         * This value is evaluated once per session, not per transaction.
+         * Has to be between 0 and 1.
+         * For example, a value of 0.5 means 50% of sessions will have profiling enabled.
+         * Replaces the deprecated [profilesSampleRate] option, which was transaction-scoped.
+         */
         val profileSessionSampleRate: Double = 0.0,
     ) : PerformanceMonitoringConfig() {
         init {

--- a/crashlogging/src/main/java/com/automattic/android/tracks/crashlogging/CrashLoggingDataProvider.kt
+++ b/crashlogging/src/main/java/com/automattic/android/tracks/crashlogging/CrashLoggingDataProvider.kt
@@ -116,11 +116,11 @@ sealed class PerformanceMonitoringConfig {
          * Mind that this value is **relative** to [sampleRate] value.
          * Has to be between 0 and 1.
          */
-        val profilesSampleRate: Double = 0.0,
+        val profileSessionSampleRate: Double = 0.0,
     ) : PerformanceMonitoringConfig() {
         init {
             assert(sampleRate in 0.0..1.0)
-            assert(profilesSampleRate in 0.0..1.0)
+            assert(profileSessionSampleRate in 0.0..1.0)
         }
     }
 }

--- a/crashlogging/src/main/java/com/automattic/android/tracks/crashlogging/internal/SentryCrashLogging.kt
+++ b/crashlogging/src/main/java/com/automattic/android/tracks/crashlogging/internal/SentryCrashLogging.kt
@@ -53,7 +53,7 @@ internal class SentryCrashLogging constructor(
                     Disabled -> Unit // no-op
                     is Enabled -> {
                         this.tracesSampleRate = config.sampleRate
-                        this.profilesSampleRate = config.profilesSampleRate
+                        this.profileSessionSampleRate = config.profileSessionSampleRate
                         profileLifecycle = ProfileLifecycle.TRACE
                         isStartProfilerOnAppStart = true
                     }

--- a/sampletracksapp/src/main/java/com/example/sampletracksapp/SampleApp.kt
+++ b/sampletracksapp/src/main/java/com/example/sampletracksapp/SampleApp.kt
@@ -28,7 +28,7 @@ class SampleApp : Application() {
                 override val locale = Locale.US
                 override val enableCrashLoggingLogs = true
                 override val performanceMonitoringConfig =
-                    PerformanceMonitoringConfig.Enabled(sampleRate = 1.0, profilesSampleRate = 1.0)
+                    PerformanceMonitoringConfig.Enabled(sampleRate = 1.0, profileSessionSampleRate = 1.0)
                 override val user = flowOf(
                     CrashLoggingUser(
                         userID = "test user id",


### PR DESCRIPTION
> UI Profiling and the previous transaction-based profiling are mutually exclusive within the same service, meaning you cannot use both at the same time. If you are setting `profiles_sample_rate` or `profiles_sampler` in your Sentry SDK configuration options, you are using transaction-based profiling. If you are setting `profile_session_sample_rate`, you are using UI Profiling.

https://docs.sentry.io/pricing/quotas/manage-ui-profile-hours/#what-if-im-already-using-transaction-based-profiling