### PR TITLE
[Dependency Update] Update `dependency-analysis` to 2.19.0

### DIFF
--- a/AutomatticTracks/build.gradle
+++ b/AutomatticTracks/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'com.android.library'
     id 'org.jetbrains.kotlin.android'
     id 'com.automattic.android.publish-to-s3'
+    id "com.autonomousapps.dependency-analysis"
 }
 
 repositories {

--- a/benchmark/build.gradle.kts
+++ b/benchmark/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     id("com.android.library")
     id("androidx.benchmark")
     id("org.jetbrains.kotlin.android")
+    id("com.autonomousapps.dependency-analysis")
 }
 
 repositories {

--- a/crashlogging/build.gradle
+++ b/crashlogging/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id "com.android.library"
     id "org.jetbrains.kotlin.android"
     id 'com.automattic.android.publish-to-s3'
+    id "com.autonomousapps.dependency-analysis"
 }
 
 repositories {

--- a/experimentation/build.gradle
+++ b/experimentation/build.gradle
@@ -4,6 +4,7 @@ plugins {
     id 'com.automattic.android.publish-to-s3'
     id "com.google.devtools.ksp"
     id "org.jetbrains.kotlinx.binary-compatibility-validator"
+    id "com.autonomousapps.dependency-analysis"
 }
 
 repositories {

--- a/sampletracksapp/build.gradle
+++ b/sampletracksapp/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'com.android.application'
     id 'org.jetbrains.kotlin.android'
     id "io.sentry.android.gradle" version "5.8.0"
+    id "com.autonomousapps.dependency-analysis"
 }
 
 repositories {

--- a/settings.gradle
+++ b/settings.gradle
@@ -3,7 +3,7 @@ pluginManagement {
     gradle.ext.kspVersion = '2.0.21-1.0.28'
     gradle.ext.agpVersion = '8.12.0'
     gradle.ext.automatticPublishToS3Version = '0.8.0'
-    gradle.ext.dependencyAnalysisVersion = '1.33.0'
+    gradle.ext.dependencyAnalysisVersion = '2.19.0'
 
     plugins {
         id 'com.android.library' version gradle.ext.agpVersion


### PR DESCRIPTION
Closes: [AINFRA-1121](https://linear.app/a8c/issue/AINFRA-1121)

---

### Description

This PR updates `dependency-analysis` to [2.19.0](https://github.com/autonomousapps/dependency-analysis-gradle-plugin/blob/main/CHANGELOG.md#version-2190)

FYI: After updating this project to AGP 8.12.0, as part of #269, the `buildHealth` command stopped working (see [scheduled build failure](https://buildkite.com/automattic/automattic-tracks-android/builds/470/steps/canvas?sid=01989148-2e5b-42de-9a9f-b1224471bd21#01989148-2f7d-4407-939f-3f7e5714d708/197-221)), most probably because it is now incompatible with this version of AGP. Updating the plugin to its latest stable version fixed this problem.

---

### Testing Instruction

Run `buildHealth` locally and make sure it completes successfully.

---

### Post Merge Instructions

- [x] ~~Trigger [schedules/dependency-analysis.yml](https://github.com/Automattic/Automattic-Tracks-Android/blob/trunk/.buildkite/schedules/dependency-analysis.yml) manually via [this](https://buildkite.com/automattic/automattic-tracks-android) `New Build` button to run the `Dependency Analysis` job again.~~ -> [Done](https://buildkite.com/automattic/automattic-tracks-android/builds/473/steps/canvas)