### PR TITLE
[Dependency Analysis] Remove Unused Dependencies

### DIFF
--- a/crashlogging/build.gradle
+++ b/crashlogging/build.gradle
@@ -16,7 +16,6 @@ dependencies {
     implementation "io.sentry:sentry-okhttp"
     implementation "io.sentry:sentry-android-fragment"
     implementation "io.sentry:sentry-compose-android"
-    implementation "androidx.annotation:annotation:$androidxAnnotationVersion"
     implementation "com.squareup.okhttp3:okhttp:$squareupOkhttpVersion"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlinxCoroutinesVersion"
     compileOnly 'androidx.compose.ui:ui:1.6.0'
@@ -25,7 +24,6 @@ dependencies {
     testImplementation "org.assertj:assertj-core:$assertjVersion"
     testImplementation "org.mockito.kotlin:mockito-kotlin:$mockitoKotlinVersion"
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$kotlinxCoroutinesVersion"
-
 }
 
 android {


### PR DESCRIPTION
Closes: [AINFRA-1181](https://linear.app/a8c/issue/AINFRA-1181)

---

### Description

This PR Removes this unused `androidx.annotation` dependency from the `crashlogging` module.

FYI: After updating the `dependency-analysis` plugin to `2.19.0`, as part of #272, this plugin started working better than before (`1.33.0`) and thus created this new advise that was previously ignored, since indeed there is no `import androidx.annotation.*` import on this `crashlogging` module.

PS: The only such one `import androidx.annotation.*` import exist on the `AutomatticTracks` module, because it (seems) that it is the only module that is still using Java classes.

---

### Testing Instructions

1. Tooling:
    - Run the `./gradlew buildHealth` task and verify that there is no `unused` related advise remaining within both reports, JSON and txt included:
        - `build-health-report.json` -> Search for `unusedCount`
        - `build-health-report.txt` -> Search for `unused`
    - Check the manually triggered [scheduled build](https://buildkite.com/automattic/automattic-tracks-android/builds/479/steps/canvas) and verify that everything works, and that these are no `unused` related advises.
2. Testing (`Optional`):
    - Smoke test the sample tracks app, try sending a report with a message and verify that everything is working as expected.
        - FYI: You could `cp gradle.properties-example gradle.properties` and set a valid `sentryTestProjectDSN`, using the `tracks-demo-android` project on A8C Sentry.