### PR TITLE
Use Call.Factory instead of OkHttpClient directly

### DIFF
--- a/experimentation/api/experimentation.api
+++ b/experimentation/api/experimentation.api
@@ -29,8 +29,8 @@ public abstract interface class com/automattic/android/experimentation/Variation
 }
 
 public final class com/automattic/android/experimentation/VariationsRepository$Companion {
-	public final fun create (Ljava/lang/String;Ljava/util/Set;Lcom/automattic/android/experimentation/ExperimentLogger;ZLjava/io/File;Lokhttp3/OkHttpClient;Lkotlinx/coroutines/CoroutineScope;Lkotlinx/coroutines/CoroutineDispatcher;)Lcom/automattic/android/experimentation/VariationsRepository;
-	public static synthetic fun create$default (Lcom/automattic/android/experimentation/VariationsRepository$Companion;Ljava/lang/String;Ljava/util/Set;Lcom/automattic/android/experimentation/ExperimentLogger;ZLjava/io/File;Lokhttp3/OkHttpClient;Lkotlinx/coroutines/CoroutineScope;Lkotlinx/coroutines/CoroutineDispatcher;ILjava/lang/Object;)Lcom/automattic/android/experimentation/VariationsRepository;
+	public final fun create (Ljava/lang/String;Ljava/util/Set;Lcom/automattic/android/experimentation/ExperimentLogger;ZLjava/io/File;Lokhttp3/Call$Factory;Lkotlinx/coroutines/CoroutineScope;Lkotlinx/coroutines/CoroutineDispatcher;)Lcom/automattic/android/experimentation/VariationsRepository;
+	public static synthetic fun create$default (Lcom/automattic/android/experimentation/VariationsRepository$Companion;Ljava/lang/String;Ljava/util/Set;Lcom/automattic/android/experimentation/ExperimentLogger;ZLjava/io/File;Lokhttp3/Call$Factory;Lkotlinx/coroutines/CoroutineScope;Lkotlinx/coroutines/CoroutineDispatcher;ILjava/lang/Object;)Lcom/automattic/android/experimentation/VariationsRepository;
 }
 
 public final class com/automattic/android/experimentation/VariationsRepository$DefaultImpls {

--- a/experimentation/src/main/java/com/automattic/android/experimentation/VariationsRepository.kt
+++ b/experimentation/src/main/java/com/automattic/android/experimentation/VariationsRepository.kt
@@ -10,6 +10,7 @@ import com.automattic.android.experimentation.repository.AssignmentsRepository
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import okhttp3.Call
 import okhttp3.OkHttpClient
 import java.io.File
 
@@ -54,7 +55,7 @@ public interface VariationsRepository {
          * @param logger to log errors and debug information.
          * @param failFast If `true`, [getVariation] will throw exceptions if the [VariationsRepository] is not initialized or if the [Experiment] is not found.
          * @param cacheDir Directory to use for caching the [Assignments]. This directory should be private to the application.
-         * @param okhttpClient to use for network operations. Defaults to a new instance of [OkHttpClient].
+         * @param callFactory to use for network operations. Defaults to a new instance of [OkHttpClient].
          * @param coroutineScope to use for async operations. Preferably a [CoroutineScope] that is tied to the lifecycle of the application.
          * @param dispatcher to use for async I/O operations. Defaults to [Dispatchers.IO].
          */
@@ -64,7 +65,7 @@ public interface VariationsRepository {
             logger: ExperimentLogger,
             failFast: Boolean,
             cacheDir: File,
-            okhttpClient: OkHttpClient = OkHttpClient(),
+            callFactory: Call.Factory = OkHttpClient(),
             coroutineScope: CoroutineScope,
             dispatcher: CoroutineDispatcher = Dispatchers.IO,
         ): VariationsRepository {
@@ -76,7 +77,7 @@ public interface VariationsRepository {
                 failFast = failFast,
                 assignmentsValidator = AssignmentsValidator(SystemClock()),
                 repository = AssignmentsRepository(
-                    ExperimentRestClient(dispatcher = dispatcher, okHttpClient = okhttpClient),
+                    ExperimentRestClient(dispatcher = dispatcher, callFactory = callFactory),
                     FileBasedCache(
                         cacheDir,
                         dispatcher = dispatcher,

--- a/experimentation/src/main/java/com/automattic/android/experimentation/remote/ExperimentRestClient.kt
+++ b/experimentation/src/main/java/com/automattic/android/experimentation/remote/ExperimentRestClient.kt
@@ -7,12 +7,12 @@ import com.automattic.android.experimentation.remote.AssignmentsDtoMapper.toAssi
 import com.squareup.moshi.Moshi
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
-import okhttp3.OkHttpClient
+import okhttp3.Call
 import okhttp3.Request
 import java.io.IOException
 
 internal class ExperimentRestClient(
-    private val okHttpClient: OkHttpClient,
+    private val callFactory: Call.Factory,
     private val moshi: Moshi = Moshi.Builder().build(),
     private val jsonAdapter: AssignmentsDtoJsonAdapter = AssignmentsDtoJsonAdapter(moshi),
     private val urlBuilder: UrlBuilder = ExPlatUrlBuilder(),
@@ -36,7 +36,7 @@ internal class ExperimentRestClient(
 
         return withContext(dispatcher) {
             try {
-                okHttpClient.newCall(request).execute().use { response ->
+                callFactory.newCall(request).execute().use { response ->
                     if (!response.isSuccessful) {
                         Result.failure(IOException("Unexpected code $response"))
                     } else {

--- a/experimentation/src/test/java/com/automattic/android/experimentation/ExPlatTest.kt
+++ b/experimentation/src/test/java/com/automattic/android/experimentation/ExPlatTest.kt
@@ -192,7 +192,7 @@ internal class ExPlatTest {
             urlBuilder = MockWebServerUrlBuilder(ExPlatUrlBuilder(), server),
             dispatcher = dispatcher,
             clock = clock,
-            okHttpClient = OkHttpClient(),
+            callFactory = OkHttpClient(),
         )
         tempCache = FileBasedCache(
             createTempDirectory().toFile(),

--- a/experimentation/src/test/java/com/automattic/android/experimentation/remote/ExperimentRestClientTest.kt
+++ b/experimentation/src/test/java/com/automattic/android/experimentation/remote/ExperimentRestClientTest.kt
@@ -103,7 +103,7 @@ internal class ExperimentRestClientTest {
         urlBuilder = urlBuilder,
         clock = { TEST_TIMESTAMP },
         dispatcher = StandardTestDispatcher(scope.testScheduler),
-        okHttpClient = OkHttpClient(),
+        callFactory = OkHttpClient(),
     )
 
     companion object {


### PR DESCRIPTION
Using `Call.Factory` instead of `OkHttpClient` allows library consumers to instantiate `OkHttpClient` lazily if desired. This is important because `OkHttpClient` initialization can take upwards of 100 ms on some Android devices, potentially causing ANRs or slowing down app startup.

This change is binary-compatible, as `Call.Factory` is a superinterface of `OkHttpClient`. However, it may be source-incompatible for Kotlin consumers that rely on named parameters, since the constructor parameter was renamed from `okhttpClient` to `callFactory`.

If this is considered a deal-breaker, I can revert the parameter name change. However, I do not think it is a significant issue, as this dependency is typically instantiated only once in most applications, making the migration effort minimal. We can also explicitly call this out in the changelog.