### PR TITLE
Fix crash loop caused by corrupted A/B testing cache file

### DIFF
--- a/experimentation/src/main/java/com/automattic/android/experimentation/local/FileBasedCache.kt
+++ b/experimentation/src/main/java/com/automattic/android/experimentation/local/FileBasedCache.kt
@@ -31,20 +31,33 @@ internal class FileBasedCache(
     init {
         scope.launch {
             withContext(context = dispatcher) {
-                latestMutable = getAssignments()
+                runCatching { latestMutable = getAssignments() }
+                    .onFailure { logger.e("Failed to load cached assignments: $it") }
             }
         }
     }
 
     suspend fun getAssignments(): Assignments? {
         return withContext(dispatcher) {
-            assignmentsFile.takeIf { it.exists() }?.readText()?.let { json: String ->
-                val fromJson = cacheDtoJsonAdapter.fromJson(json) ?: return@let null
-
-                fromJson.assignmentsDto.toAssignments(
-                    fetchedAt = fromJson.fetchedAt,
-                    anonymousId = fromJson.anonymousId,
-                )
+            assignmentsFile.takeIf { it.exists() }?.let { file ->
+                val json = file.readText()
+                if (json.isBlank()) {
+                    logger.e("Cached assignments file is empty, deleting: ${file.path}")
+                    file.delete()
+                    return@withContext null
+                }
+                runCatching { cacheDtoJsonAdapter.fromJson(json) }
+                    .onFailure {
+                        logger.e("Cached assignments file is corrupted, deleting: ${file.path}")
+                        file.delete()
+                    }
+                    .getOrNull()
+                    ?.let { fromJson ->
+                        fromJson.assignmentsDto.toAssignments(
+                            fetchedAt = fromJson.fetchedAt,
+                            anonymousId = fromJson.anonymousId,
+                        )
+                    }
             }
         }
     }

--- a/experimentation/src/main/java/com/automattic/android/experimentation/local/FileBasedCache.kt
+++ b/experimentation/src/main/java/com/automattic/android/experimentation/local/FileBasedCache.kt
@@ -32,7 +32,7 @@ internal class FileBasedCache(
         scope.launch {
             withContext(context = dispatcher) {
                 runCatching { latestMutable = getAssignments() }
-                    .onFailure { logger.e("Failed to load cached assignments: $it") }
+                    .onFailure { throwable -> logger.e("Failed to load cached assignments", throwable) }
             }
         }
     }
@@ -47,8 +47,8 @@ internal class FileBasedCache(
                     return@withContext null
                 }
                 runCatching { cacheDtoJsonAdapter.fromJson(json) }
-                    .onFailure {
-                        logger.e("Cached assignments file is corrupted, deleting: ${file.path}")
+                    .onFailure { throwable ->
+                        logger.e("Cached assignments file is corrupted, deleting: ${file.path}", throwable)
                         file.delete()
                     }
                     .getOrNull()

--- a/experimentation/src/test/java/com/automattic/android/experimentation/local/FileBasedCacheTest.kt
+++ b/experimentation/src/test/java/com/automattic/android/experimentation/local/FileBasedCacheTest.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Rule
 import org.junit.Test
@@ -64,6 +65,30 @@ internal class FileBasedCacheTest {
         val sut = fileBasedCache(this)
 
         sut.clear()
+    }
+
+    @Test
+    fun `getting assignments from empty file returns null and deletes the file`() = runTest {
+        val cacheDir = tempDir.newFolder()
+        val assignmentsFile = File(cacheDir, "assignments.json").apply { createNewFile() }
+        val sut = fileBasedCache(this, cacheDir = cacheDir)
+
+        val result = sut.getAssignments()
+
+        assertNull(result)
+        assertFalse(assignmentsFile.exists())
+    }
+
+    @Test
+    fun `getting assignments from corrupted file returns null and deletes the file`() = runTest {
+        val cacheDir = tempDir.newFolder()
+        val assignmentsFile = File(cacheDir, "assignments.json").apply { writeText("{corrupted") }
+        val sut = fileBasedCache(this, cacheDir = cacheDir)
+
+        val result = sut.getAssignments()
+
+        assertNull(result)
+        assertFalse(assignmentsFile.exists())
     }
 
     @Test


### PR DESCRIPTION
## Problem

My Pocket Casts has been stuck in a crash loop. Every launch fails with:

```
FATAL EXCEPTION: DefaultDispatcher-worker-1
java.io.EOFException: End of input
    at com.automattic.android.experimentation.local.CacheDtoJsonAdapter.b
```

After digging through the source, I found that `assignments.json` in `files/experiments/` must have been left empty by an interrupted write. The stack trace makes this clear: `FileNotFoundException` would mean the file doesn't exist; a partial/truncated JSON would give `JsonDataException`. `EOFException: End of input` is specifically what Moshi throws when `fromJson()` receives an empty string — meaning `readText()` succeeded but returned `""`.

The reason I can't recover without a code fix: the file lives in `filesDir`, not `cacheDir`, so clearing the app cache does nothing. Clearing app data would fix the crash but I have starred episodes stored locally that are no longer available in the feed — that data would be gone permanently.

## Fix

Treat an empty or unparseable file as a cache miss, delete it, and let the library re-fetch from the server. I also wrapped the `init` coroutine in `runCatching` so future read failures degrade gracefully rather than crashing the process.

## Follow-up

Worth discussing whether this file should live in `cacheDir` instead of `filesDir` — it's a network cache that can always be re-fetched, and using `cacheDir` would mean Clear Cache recovers users from this situation automatically in the future.

## Test plan

- [x] Added unit test: empty `assignments.json` returns `null` and deletes the file
- [x] Added unit test: corrupted `assignments.json` returns `null` and deletes the file
- [x] Existing tests continue to pass