### PR TITLE
Null-guard Configuration.locale in MessageBuilder

### DIFF
--- a/AutomatticTracks/src/main/java/com/automattic/android/tracks/MessageBuilder.java
+++ b/AutomatticTracks/src/main/java/com/automattic/android/tracks/MessageBuilder.java
@@ -65,7 +65,11 @@ class MessageBuilder {
         }
 
         try {
-            commonProps.put(USER_LANG_KEY, ctx.getResources().getConfiguration().locale.toString());
+            // Locale can be transiently null on some Samsung devices during a locale change.
+            Locale locale = ctx.getResources().getConfiguration().locale;
+            if (locale != null) {
+                commonProps.put(USER_LANG_KEY, locale.toString());
+            }
         } catch (JSONException e) {
             Log.e(TracksClient.LOGTAG, "Cannot add the device language property to request commons.");
         }


### PR DESCRIPTION
See: https://a8c.sentry.io/issues/7311890982/?project=5731682&referrer=project-issue-stream&seerDrawer=true

## Summary
- Fixes NPE at `MessageBuilder.java:68` when `Configuration.locale` is transiently null during a locale transition on Samsung SM-A566B devices (Android 15/16, firmware `BP2A.250605.031.A3.*`). The NPE fires on the Tracks analytics flush background thread and crashes the host app.
- When the locale is null, the `_lg` property is skipped entirely rather than emitted as an empty string, so the server sees a missing field instead of mixing a fallback value into the real `Locale.ROOT` bucket in analytics.

## Context
Reported as JETPACK-ANDROID-1G35. Reproduces when the device/app locale is switched to `hr`, `sr`, or `bs` on an affected Samsung A56 build and an analytics event fires mid-transition. `Configuration.locale` briefly returns null, violating the documented JVM/Android contract, and `.toString()` throws.

Only `MessageBuilder.createRequestCommonPropsJSONObject()` is patched here — that's the exact call site named in the crash report. `DeviceInformation.java:101-102` has a similar `Locale.getDefault().toString()` pattern but runs once during `TracksClient` init; it could be hardened in a follow-up if we want full library-side coverage.

Note: the original bug report describes the crash as `Locale.getDefault().toString()`, but line 68 actually reads `Configuration.locale` — different field, same NPE shape. The fix targets the real code path.

## Test plan
- [ ] Build: `./gradlew :AutomatticTracks:assembleDebug`
- [ ] Lint: `./gradlew :AutomatticTracks:lintDebug`

🤖 Generated with [Claude Code](https://claude.com/claude-code)