### PR TITLE
chore: pin third-party GitHub Actions to SHAs + enable Dependabot github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,14 @@ updates:
       interval: "daily"
     allow:
       - dependency-name: "io.sentry:sentry-bom"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -7,4 +7,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: gradle/wrapper-validation-action@v1
+      - uses: gradle/wrapper-validation-action@56b90f209b02bf6d1deae490e9ef18b21a389cd4 # v1.1.0


### PR DESCRIPTION
Two changes in one PR:

1. Pin `gradle/wrapper-validation-action@v1` to a commit SHA (tag preserved as trailing comment) to harden against supply-chain risk on mutable tags.
2. Enable Dependabot for the `github-actions` ecosystem so pinned SHAs get automatic refresh PRs (weekly, grouped).

Tracking: DEVPROD-1072.