### PR TITLE
Update okhttp version to 4.9.2 to resolve HostnameVerifier security issue

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ ext {
     googleMaterialVersion = '1.3.0'
     kotlinxCoroutinesVersion = '1.6.4'
     sentryBomVersion = '8.18.0'
-    squareupOkhttpVersion = '4.9.0'
+    squareupOkhttpVersion = '4.9.2'
 
     // test
     assertjVersion = '3.19.0'


### PR DESCRIPTION
While this is still an older version of OkHttp (we're at 4.9.x when OkHttp is on 5.x), I take it that we're keeping changes small. I had a dependabot security alert on my app that resolved into the CrashLogging library taking a transitive dependency with a potential security issue that's fixed in 4.9.2, hence bumping that version here.

> Fix: Strictly verify hostnames used with OkHttp’s HostnameVerifier. Programs that make direct manual calls to HostnameVerifier could be defeated if the hostnames they pass in are not strictly ASCII. This issue is tracked as [CVE-2021-0341](https://nvd.nist.gov/vuln/detail/CVE-2021-0341).

see A-171980069 see https://square.github.io/okhttp/changelogs/changelog_4x/#version-492